### PR TITLE
Refetch room data after reconnecting

### DIFF
--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -1,0 +1,51 @@
+export type DatabaseChange<T> =
+	| { eventType: 'INSERT'; new: T; old: Partial<T> }
+	| { eventType: 'UPDATE'; new: T; old: Partial<T> }
+	| { eventType: 'DELETE'; new: Partial<T>; old: Partial<T> };
+
+type KeyOf<T> = (row: Partial<T>) => string | undefined;
+
+/**
+ * Apply a Postgres change to a snapshot without creating duplicate rows.
+ * UPDATE removes the old key first because a primary-key column may have changed.
+ */
+export function applyDatabaseChange<T>(
+	rows: readonly T[],
+	change: DatabaseChange<T>,
+	keyOf: KeyOf<T>
+): T[] {
+	if (change.eventType === 'DELETE') {
+		const oldKey = keyOf(change.old);
+		return oldKey === undefined ? [...rows] : rows.filter((row) => keyOf(row) !== oldKey);
+	}
+
+	const newKey = keyOf(change.new);
+	if (newKey === undefined) return [...rows];
+
+	const oldKey = change.eventType === 'UPDATE' ? keyOf(change.old) : undefined;
+	const existingIndex = rows.findIndex((row) => {
+		const key = keyOf(row);
+		return key === newKey || (oldKey !== undefined && key === oldKey);
+	});
+
+	if (existingIndex === -1) return [...rows, change.new];
+
+	const next = [...rows];
+	next[existingIndex] = change.new;
+	return next.filter((row, index) => {
+		if (index === existingIndex) return true;
+		const key = keyOf(row);
+		return key !== newKey && (oldKey === undefined || key !== oldKey);
+	});
+}
+
+export function replayDatabaseChanges<T>(
+	rows: readonly T[],
+	changes: readonly DatabaseChange<T>[],
+	keyOf: KeyOf<T>
+): T[] {
+	return changes.reduce(
+		(current, change) => applyDatabaseChange(current, change, keyOf),
+		[...rows]
+	);
+}

--- a/src/routes/room/[room=uuid]/+page.svelte
+++ b/src/routes/room/[room=uuid]/+page.svelte
@@ -20,6 +20,8 @@
 	import { copyToClipboard } from '$lib/actions';
 	import type { You } from './ViewSchedules';
 	import Engineer from './Engineer.svelte';
+	import { applyDatabaseChange, replayDatabaseChanges, type DatabaseChange } from '$lib/realtime';
+	import type { RealtimeChannel } from '@supabase/supabase-js';
 
 	let { data }: { data: PageData } = $props();
 	let supabase = $derived(data.supabase);
@@ -41,46 +43,98 @@
 	let onlyMatching: boolean = $state(false);
 	let realtimeStatus: 'SUBSCRIBED' | 'TIMED_OUT' | 'CLOSED' | 'CHANNEL_ERROR' = $state('CLOSED');
 	let room = $derived(page.params.room!);
-	onMount(async () => {
-		{
-			const { data, error } = await getClasses(room);
-			// did not convert to console.assert
-			// to appease TypeScript
-			if (error !== null) {
-				throw error;
+	let refreshInFlight = false;
+	let refreshAgain = false;
+	let scheduleEventsDuringRefresh: DatabaseChange<Schedule>[] = [];
+	let classEventsDuringRefresh: DatabaseChange<Class>[] = [];
+
+	const scheduleKey = (schedule: Partial<Schedule>) =>
+		schedule.room && schedule.student ? `${schedule.room}:${schedule.student}` : undefined;
+	const classKey = (classRow: Partial<Class>) => classRow.id;
+
+	function recoverMissingUser() {
+		you = null;
+		window.localStorage.removeItem(room);
+	}
+
+	function reconcileUser(nextSchedules: Schedule[]) {
+		if (you === null || you === 'tentative') return;
+		const currentUser = you;
+		const currentSchedule = nextSchedules.find((schedule) => schedule.student === currentUser.name);
+		if (currentSchedule === undefined) {
+			recoverMissingUser();
+			return;
+		}
+		you = { name: currentUser.name, schedule: currentSchedule };
+		window.localStorage.setItem(room, JSON.stringify(you));
+	}
+
+	async function refreshRoom() {
+		if (refreshInFlight) {
+			refreshAgain = true;
+			return;
+		}
+
+		refreshInFlight = true;
+		scheduleEventsDuringRefresh = [];
+		classEventsDuringRefresh = [];
+		try {
+			const [scheduleResult, classResult] = await Promise.all([
+				supabase.from('schedules').select('*').eq('room', room),
+				getClasses(room)
+			]);
+			if (scheduleResult.error !== null) throw scheduleResult.error;
+			if (classResult.error !== null) throw classResult.error;
+
+			const nextSchedules = replayDatabaseChanges(
+				scheduleResult.data,
+				scheduleEventsDuringRefresh,
+				scheduleKey
+			);
+			schedules = nextSchedules;
+			classes = replayDatabaseChanges(classResult.data, classEventsDuringRefresh, classKey);
+			reconcileUser(nextSchedules);
+		} catch (error) {
+			console.error('Failed to refresh room after reconnecting', error);
+			addToast('Could not refresh this room after reconnecting', 'error');
+		} finally {
+			refreshInFlight = false;
+			if (refreshAgain) {
+				refreshAgain = false;
+				void refreshRoom();
 			}
-			classes = data;
 		}
-		// Load it from localStorage
+	}
+
+	function applyScheduleChange(change: DatabaseChange<Schedule>) {
+		if (refreshInFlight) scheduleEventsDuringRefresh.push(change);
+		schedules = applyDatabaseChange(schedules, change, scheduleKey);
+		if (change.eventType === 'INSERT') {
+			addToast(`${change.new.student} just added their schedule to this room`);
+		}
+		if (change.eventType !== 'INSERT') reconcileUser(schedules);
+	}
+
+	function applyClassChange(change: DatabaseChange<Class>) {
+		if (refreshInFlight) classEventsDuringRefresh.push(change);
+		classes = applyDatabaseChange(classes, change, classKey);
+	}
+
+	onMount(() => {
 		you = JSON.parse(window.localStorage.getItem(room) ?? 'null');
-		if (
-			// If your log-in exists
-			// But the database forgot about you
-			you !== null &&
-			you !== 'tentative' &&
-			(
-				await supabase
-					.from('schedules')
-					.select('*')
-					.eq('room', room)
-					.eq('student', you.name)
-					.single()
-			).data === null
-		) {
-			// you'll have to do the whole process again
-			you = null;
-			window.localStorage.removeItem(room);
-			// old code:
-			// let toInsert: Schedule = {
-			// 	...you['schedule'],
-			// 	room,
-			// 	student: you.name
-			// };
-			// // they should be equivalent
-			// console.assert(isEqual(toInsert, you.schedule));
-		}
-		// Supabase Realtime
-		supabase
+
+		let previousStatus = realtimeStatus;
+		let channel: RealtimeChannel;
+		const handleOffline = () => {
+			previousStatus = 'CLOSED';
+		};
+		const handleOnline = () => {
+			if (realtimeStatus === 'SUBSCRIBED') void refreshRoom();
+		};
+		window.addEventListener('offline', handleOffline);
+		window.addEventListener('online', handleOnline);
+
+		channel = supabase
 			.channel('schema-db-changes')
 			.on<Schedule>(
 				'postgres_changes',
@@ -94,19 +148,12 @@
 					// is being validated)
 					filter: `room=eq.${sqlEscape(room)}`
 				},
-				(payload) => {
-					if (payload.eventType === 'INSERT') {
-						schedules = [...schedules, payload.new];
-						addToast(`${payload.new.student} just added their schedule to this room`);
-					}
-					console.log('1', payload);
-				}
+				(payload) => applyScheduleChange(payload as DatabaseChange<Schedule>)
 			)
 			.on<Class>(
 				'postgres_changes',
 				{
-					// The only valid event (when I'm not clearing the db/devving)
-					event: 'INSERT',
+					event: '*',
 					schema: 'public',
 					table: 'classes',
 					// please don't let this be an SQL injection
@@ -115,13 +162,21 @@
 					// is being validated)
 					filter: `room=eq.${sqlEscape(room)}`
 				},
-				async (payload) => {
-					classes = [...classes, payload.new];
-				}
+				(payload) => applyClassChange(payload as DatabaseChange<Class>)
 			)
 			.subscribe((status) => {
+				const reconnected = status === 'SUBSCRIBED' && previousStatus !== 'SUBSCRIBED';
 				realtimeStatus = status;
+				previousStatus = status;
+				if (reconnected && navigator.onLine) void refreshRoom();
 			});
+		void refreshRoom();
+
+		return () => {
+			window.removeEventListener('offline', handleOffline);
+			window.removeEventListener('online', handleOnline);
+			void supabase.removeChannel(channel);
+		};
 	});
 	function onInfoSubmitted(detail: { name: string; schedule: VirtualSchedule }) {
 		const toInsert = { ...detail.schedule, room, student: detail.name };

--- a/tests/realtime.spec.ts
+++ b/tests/realtime.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+import { applyDatabaseChange, replayDatabaseChanges } from '../src/lib/realtime';
+
+type Row = { id: string; value: string };
+const keyOf = (row: Partial<Row>) => row.id;
+
+test('database changes are applied without duplicate rows', () => {
+	const original = [{ id: 'one', value: 'old' }];
+	const inserted = applyDatabaseChange(
+		original,
+		{ eventType: 'INSERT', new: { id: 'one', value: 'new' }, old: {} },
+		keyOf
+	);
+
+	expect(inserted).toEqual([{ id: 'one', value: 'new' }]);
+	expect(
+		applyDatabaseChange(inserted, { eventType: 'DELETE', new: {}, old: { id: 'one' } }, keyOf)
+	).toEqual([]);
+});
+
+test('events received during a fetch are replayed over its snapshot', () => {
+	const staleSnapshot = [
+		{ id: 'updated', value: 'old' },
+		{ id: 'deleted', value: 'remove me' }
+	];
+	const events = [
+		{
+			eventType: 'INSERT' as const,
+			new: { id: 'inserted', value: 'present' },
+			old: {}
+		},
+		{
+			eventType: 'UPDATE' as const,
+			new: { id: 'updated', value: 'current' },
+			old: { id: 'updated' }
+		},
+		{
+			eventType: 'DELETE' as const,
+			new: {},
+			old: { id: 'deleted' }
+		}
+	];
+
+	expect(replayDatabaseChanges(staleSnapshot, events, keyOf)).toEqual([
+		{ id: 'updated', value: 'current' },
+		{ id: 'inserted', value: 'present' }
+	]);
+});
+
+test('an update can change a row key without leaving the old row behind', () => {
+	expect(
+		applyDatabaseChange(
+			[{ id: 'old-key', value: 'value' }],
+			{
+				eventType: 'UPDATE',
+				new: { id: 'new-key', value: 'value' },
+				old: { id: 'old-key' }
+			},
+			keyOf
+		)
+	).toEqual([{ id: 'new-key', value: 'value' }]);
+});


### PR DESCRIPTION
## Summary

- re-fetch room schedules and classes after the browser or realtime channel reconnects
- buffer and replay concurrent realtime inserts, updates, and deletes over fetched snapshots so local state converges without duplicates
- preserve the current user with their refreshed schedule, or clear the existing local identity when that schedule was deleted
- report refresh failures without resubscribing or creating a retry loop
- clean up channel and browser event listeners when leaving the room

## Root cause

The realtime status callback only updated the connection badge. Supabase Realtime does not replay database changes missed while a browser is offline or suspended, so local room state stayed stale until a full page reload.

## Validation

- `pnpm exec eslint src/lib/realtime.ts 'src/routes/room/[room=uuid]/+page.svelte' tests/realtime.spec.ts`
- `PUBLIC_SUPABASE_URL=https://example.supabase.co PUBLIC_SUPABASE_ANON_KEY=test-key pnpm test tests/realtime.spec.ts` (3 passed)
- production build through the Playwright web server

Repository-wide `svelte-check` remains blocked by two pre-existing type errors in `src/lib/engineer.ts`.

Closes #24
