### PR TITLE
Improve teacher and class name display

### DIFF
--- a/src/lib/ClassPicker.svelte
+++ b/src/lib/ClassPicker.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Fuse from 'fuse.js';
 	import type { Class } from './InfoInput';
-	import { titlecase } from '$lib/utils';
+	import { formatClassName, formatTeacherName } from '$lib/utils';
 	import { addToast } from './toasts.svelte';
 
 	type MenuItem = Class & { used?: string };
@@ -42,7 +42,7 @@
 	let isValidClassInfo = $derived(classNameValid && firstNameValid && lastNameValid);
 </script>
 
-<div class="tooltip" data-tip={selectedClassName ? titlecase(selectedClassName) : undefined}>
+<div class="tooltip" data-tip={selectedClassName ? formatClassName(selectedClassName) : undefined}>
 	<button
 		class="btn m-1"
 		class:btn-success={selected != null}
@@ -141,19 +141,19 @@
 						}}
 					>
 						<span class:active={isSelected}
-							>{titlecase(klass['name'])}
+							>{formatClassName(klass['name'])}
 							<span class="text-sm text-gray-500" class:text-white={isSelected}
-								>{titlecase(klass.teacher_first)} {titlecase(klass.teacher_last)}</span
+								>{formatTeacherName(`${klass.teacher_first} ${klass.teacher_last}`)}</span
 							></span
 						>
 					</li>
 				{:else}
 					<li class="disabled">
 						<span
-							>{titlecase(klass['name'])}
+							>{formatClassName(klass['name'])}
 							<span class="text-sm text-gray-500"
-								>{titlecase(klass.teacher_first)}
-								{titlecase(klass.teacher_last)} (already used in {klass.used})</span
+								>{formatTeacherName(`${klass.teacher_first} ${klass.teacher_last}`)} (already used in
+								{klass.used})</span
 							></span
 						>
 					</li>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -55,8 +55,75 @@ export const flyAndScale = (
 	};
 };
 
-export function titlecase(x: string) {
-	return x[0].toUpperCase() + x.slice(1);
+const CLASS_ACRONYMS = new Set([
+	'ab',
+	'ap',
+	'avid',
+	'bc',
+	'cte',
+	'da',
+	'ela',
+	'esl',
+	'hl',
+	'ib',
+	'pe',
+	'se',
+	'sl',
+	'stem',
+	'us'
+]);
+
+const ROMAN_NUMERAL = /^(?=[ivxlcdm]+$)m{0,4}(cm|cd|d?c{0,3})(xc|xl|l?x{0,3})(ix|iv|v?i{0,3})$/i;
+const DOTTED_INITIALISM = /^(?:[a-z]\.){2,}$/i;
+
+function capitalizeWord(word: string) {
+	return word.replace(/^\p{L}/u, (letter) => letter.toLocaleUpperCase());
+}
+
+function formatClassSegment(segment: string) {
+	return CLASS_ACRONYMS.has(segment) ? segment.toLocaleUpperCase() : capitalizeWord(segment);
+}
+
+function formatClassWord(word: string) {
+	const lower = word.toLocaleLowerCase();
+
+	if (CLASS_ACRONYMS.has(lower)) return lower.toLocaleUpperCase();
+	if (DOTTED_INITIALISM.test(lower)) return lower.toLocaleUpperCase();
+	if (ROMAN_NUMERAL.test(lower)) return lower.toLocaleUpperCase();
+	if (/^\d+[a-z]$/i.test(lower)) {
+		return lower.slice(0, -1) + lower.at(-1)?.toLocaleUpperCase();
+	}
+
+	return lower
+		.split(/([-–—/])/)
+		.map((part) => (/[-–—/]/.test(part) ? part : formatClassSegment(part)))
+		.join('');
+}
+
+/** Format a canonical class name for display without changing the stored value. */
+export function formatClassName(className: string) {
+	return className.trim().replace(/\s+/g, ' ').split(' ').map(formatClassWord).join(' ');
+}
+
+function formatNamePart(part: string, index: number) {
+	const lower = part.toLocaleLowerCase();
+
+	if (/^[a-z]\.?$/i.test(lower))
+		return lower[0].toLocaleUpperCase() + (lower.endsWith('.') ? '.' : '');
+	if (DOTTED_INITIALISM.test(lower) || ROMAN_NUMERAL.test(lower)) return lower.toLocaleUpperCase();
+	if (index > 0 && /^(da|de|del|der|di|la|le|van|von)$/i.test(lower)) return lower;
+
+	return lower
+		.split(/([-'’])/)
+		.map((segment) => (/[-'’]/.test(segment) ? segment : capitalizeWord(segment)))
+		.join('')
+		.replace(/^Mc(\p{L})/u, (_, letter: string) => `Mc${letter.toLocaleUpperCase()}`)
+		.replace(/^(Jr|Sr)$/u, '$1.');
+}
+
+/** Format a canonical teacher name for display without changing the stored value. */
+export function formatTeacherName(name: string) {
+	return name.trim().replace(/\s+/g, ' ').split(' ').map(formatNamePart).join(' ');
 }
 export function sqlEscape(str: string) {
 	// this better work well
@@ -86,7 +153,7 @@ export function sqlEscape(str: string) {
 		}
 	});
 }
-export function normalize(className: string) {
+export function normalizeClassName(className: string) {
 	return (
 		className
 			.toLowerCase()
@@ -99,6 +166,12 @@ export function normalize(className: string) {
 			.replace(/\s+/, ' ')
 	);
 }
+
+/** Preserve the existing teacher storage/search/uniqueness semantics. */
+export function normalizeTeacherName(name: string) {
+	return name.trim().toLocaleLowerCase();
+}
+
 export type ArrElement<ArrType> = ArrType extends readonly (infer ElementType)[]
 	? ElementType
 	: never;

--- a/src/routes/room/[room=uuid]/+page.svelte
+++ b/src/routes/room/[room=uuid]/+page.svelte
@@ -9,7 +9,7 @@
 	import InfoInput from '$lib/InfoInput.svelte';
 
 	import { page } from '$app/state';
-	import { sqlEscape, normalize } from '$lib/utils';
+	import { sqlEscape, normalizeClassName, normalizeTeacherName } from '$lib/utils';
 	import { onMount } from 'svelte';
 
 	import type { VirtualSchedule, Classes, Class, Schedule } from '$lib/InfoInput.d';
@@ -145,9 +145,9 @@
 		lastName: string;
 	}) {
 		const payload = {
-			name: normalize(className),
-			teacher_first: firstName.trim().toLowerCase(),
-			teacher_last: lastName.trim().toLowerCase(),
+			name: normalizeClassName(className),
+			teacher_first: normalizeTeacherName(firstName),
+			teacher_last: normalizeTeacherName(lastName),
 			room
 		};
 		const { data, error } = await supabase.from('classes').insert([payload]).select();

--- a/src/routes/room/[room=uuid]/ScheduleDisplay.svelte
+++ b/src/routes/room/[room=uuid]/ScheduleDisplay.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { titlecase } from '$lib/utils';
+	import { formatClassName, formatTeacherName } from '$lib/utils';
 	import type { VirtualSchedule, Class } from '$lib/InfoInput.d';
 	let {
 		them,
@@ -40,10 +40,9 @@
 							class:text-success-content={aInCommon}
 						>
 							<span
-								>{titlecase(classA['name'])}
+								>{formatClassName(classA['name'])}
 								<span class="text-xs text-gray-500"
-									>{titlecase(classA['teacher_first'])}
-									{titlecase(classA['teacher_last'])}</span
+									>{formatTeacherName(`${classA['teacher_first']} ${classA['teacher_last']}`)}</span
 								></span
 							>
 						</div></td
@@ -55,10 +54,9 @@
 							class:text-success-content={bInCommon}
 						>
 							<span
-								>{titlecase(classB['name'])}
+								>{formatClassName(classB['name'])}
 								<span class="text-xs text-gray-500"
-									>{titlecase(classB['teacher_first'])}
-									{titlecase(classB['teacher_last'])}</span
+									>{formatTeacherName(`${classB['teacher_first']} ${classB['teacher_last']}`)}</span
 								></span
 							>
 						</div></td

--- a/src/routes/room/[room=uuid]/Search.svelte
+++ b/src/routes/room/[room=uuid]/Search.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Class, Schedule, UnfinishedSchedule } from '$lib/InfoInput';
-	import { titlecase } from '$lib/utils';
+	import { formatClassName, formatTeacherName } from '$lib/utils';
 	import { isEqual } from 'lodash-es';
 	import ViewSchedule from './ViewSchedule.svelte';
 	import type { ResolvedYou } from './ViewSchedules';
@@ -12,8 +12,11 @@
 		schedules = [],
 		you,
 		getClass
-	}: { schedules?: Schedule[]; you: ResolvedYou; getClass: (id: string) => Promise<Class> } =
-		$props();
+	}: {
+		schedules?: Schedule[];
+		you: ResolvedYou;
+		getClass: (id: string) => Promise<Class>;
+	} = $props();
 	let sharedClass: UnfinishedSchedule = $state({});
 	let filtered = $derived(
 		schedules
@@ -21,7 +24,9 @@
 			.filter((schedule) =>
 				allPeriods
 					.map((period) => {
-						return sharedClass[period] !== undefined ? schedule[period] == sharedClass[period] : true;
+						return sharedClass[period] !== undefined
+							? schedule[period] == sharedClass[period]
+							: true;
 					})
 					.every((x) => x)
 			)
@@ -65,10 +70,11 @@
 									}}
 								>
 									<span
-										>{titlecase(classA['name'])}
+										>{formatClassName(classA['name'])}
 										<span class="text-xs text-gray-500"
-											>{titlecase(classA['teacher_first'])}
-											{titlecase(classA['teacher_last'])}</span
+											>{formatTeacherName(
+												`${classA['teacher_first']} ${classA['teacher_last']}`
+											)}</span
 										></span
 									>
 								</button></td
@@ -86,10 +92,11 @@
 									}}
 								>
 									<span
-										>{titlecase(classB['name'])}
+										>{formatClassName(classB['name'])}
 										<span class="text-xs text-gray-500"
-											>{titlecase(classB['teacher_first'])}
-											{titlecase(classB['teacher_last'])}</span
+											>{formatTeacherName(
+												`${classB['teacher_first']} ${classB['teacher_last']}`
+											)}</span
 										></span
 									>
 								</button></td

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+import {
+	formatClassName,
+	formatTeacherName,
+	normalizeClassName,
+	normalizeTeacherName
+} from '../src/lib/utils';
+
+test.describe('storage normalization', () => {
+	test('keeps the existing class canonicalization behavior', () => {
+		expect(normalizeClassName('  AP Biology II  ')).toBe('ap biology 2');
+		expect(normalizeClassName('Space & Electricity')).toBe('se');
+	});
+
+	test('keeps teacher matching case-insensitive and trimmed', () => {
+		expect(normalizeTeacherName("  O'NEILL ")).toBe("o'neill");
+	});
+});
+
+test.describe('class display formatting', () => {
+	test('formats multi-word names, known acronyms, and numerals', () => {
+		expect(formatClassName('ap united states history 2')).toBe('AP United States History 2');
+		expect(formatClassName('ib english literature iii')).toBe('IB English Literature III');
+		expect(formatClassName('pre-ap calculus ab')).toBe('Pre-AP Calculus AB');
+		expect(formatClassName('stem lab 2b')).toBe('STEM Lab 2B');
+	});
+
+	test('preserves punctuation and formats dotted initialisms', () => {
+		expect(formatClassName('u.s. history')).toBe('U.S. History');
+		expect(formatClassName('computer-aided design/art')).toBe('Computer-Aided Design/Art');
+	});
+});
+
+test.describe('teacher display formatting', () => {
+	test('formats full names, initials, apostrophes, and hyphens', () => {
+		expect(formatTeacherName("j. o'neill-smith")).toBe("J. O'Neill-Smith");
+		expect(formatTeacherName('j.r.r. tolkien')).toBe('J.R.R. Tolkien');
+	});
+
+	test('formats name particles, suffixes, and common Mc names', () => {
+		expect(formatTeacherName('ana de la cruz')).toBe('Ana de la Cruz');
+		expect(formatTeacherName('sean mcdonald jr')).toBe('Sean McDonald Jr.');
+	});
+});


### PR DESCRIPTION
## Summary

- separate canonical storage normalization from display formatting
- add dedicated class and teacher formatters for acronyms, numerals, punctuation, initials, and multi-word names
- apply the formatters consistently in the class picker, schedule table, and shared-class filters
- add focused normalization and display-formatting tests

## Impact

Stored class and teacher values remain unchanged, so search and database uniqueness semantics are preserved. Displayed values now use readable casing such as `AP United States History 2`, `Pre-AP Calculus AB`, and `J. O'Neill-Smith`.

## Verification

- `PUBLIC_SUPABASE_URL=https://example.supabase.co PUBLIC_SUPABASE_ANON_KEY=placeholder pnpm exec playwright test tests/utils.spec.ts` (6 passed)
- changed files pass Prettier and ESLint
- `pnpm check` reaches the repository baseline: it still reports the two pre-existing type errors in `src/lib/engineer.ts`
- repository-wide `pnpm lint` still stops on the pre-existing formatting issue in generated `src/lib/supabase.d.ts`

Closes #23
