### PR TITLE
Pin selected class first in picker menu

### DIFF
--- a/src/lib/ClassPicker.svelte
+++ b/src/lib/ClassPicker.svelte
@@ -3,6 +3,7 @@
 	import type { Class } from './InfoInput';
 	import { titlecase } from '$lib/utils';
 	import { addToast } from './toasts.svelte';
+	import { pinSelectedItem } from './classPicker';
 
 	type MenuItem = Class & { used?: string };
 
@@ -30,11 +31,14 @@
 		})
 	);
 	let filtered = $derived(
-		className == ''
-			? classes.map((x) => {
-					return { item: x };
-				})
-			: searcher.search(className + firstName + lastName)
+		pinSelectedItem(
+			className == ''
+				? classes.map((x) => {
+						return { item: x };
+					})
+				: searcher.search(className + firstName + lastName),
+			selected
+		)
 	);
 	let classNameValid = $derived(className.length > 0);
 	let firstNameValid = $derived(/^\w+$/.test(firstName.trim()));

--- a/src/lib/classPicker.ts
+++ b/src/lib/classPicker.ts
@@ -1,0 +1,16 @@
+export function pinSelectedItem<T extends { item: { id: string } }>(
+	items: T[],
+	selected: string | null | undefined
+): T[] {
+	const selectedIndex = items.findIndex(({ item }) => item.id === selected);
+
+	if (selectedIndex <= 0) {
+		return items;
+	}
+
+	return [
+		items[selectedIndex],
+		...items.slice(0, selectedIndex),
+		...items.slice(selectedIndex + 1)
+	];
+}

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -1,4 +1,32 @@
 import { expect, test } from '@playwright/test';
+import { pinSelectedItem } from '../src/lib/classPicker';
+
+const entries = ['algebra', 'biology', 'chemistry'].map((id, rank) => ({
+	item: { id },
+	rank
+}));
+
+test.describe('class picker ordering', () => {
+	test('pins the selected class first in the empty-query class list', () => {
+		const ordered = pinSelectedItem(entries, 'chemistry');
+
+		expect(ordered.map(({ item }) => item.id)).toEqual(['chemistry', 'algebra', 'biology']);
+	});
+
+	test('pins a matching selected class without changing the ranking of other search results', () => {
+		const searchResults = [entries[1], entries[2], entries[0]];
+		const ordered = pinSelectedItem(searchResults, 'algebra');
+
+		expect(ordered).toEqual([entries[0], entries[1], entries[2]]);
+		expect(ordered.filter(({ item }) => item.id === 'algebra')).toHaveLength(1);
+	});
+
+	test('does not add the selected class when it does not match the search', () => {
+		const searchResults = [entries[1], entries[2]];
+
+		expect(pinSelectedItem(searchResults, 'algebra')).toBe(searchResults);
+	});
+});
 
 test('index page has expected h1', async ({ page }) => {
 	await page.goto('/');


### PR DESCRIPTION
## Summary

- pin the active period selection above the normal class ordering
- preserve Fuse search ranking for every other matching class
- avoid inserting the selected class when it does not match the current search
- cover empty-query, matching-query, ranking, and duplicate behavior with tests

## Root cause

The picker rendered the classes array or Fuse results directly, so a selected class retained its original or search-ranked position instead of being promoted for the active period.

## Validation

- pnpm exec eslint src/lib/ClassPicker.svelte src/lib/classPicker.ts tests/test.spec.ts
- Playwright suite: 4 passed
- production build completed as part of the Playwright web-server setup

Closes #26