### PR TITLE
Make the current user schedule first and visually distinct

### DIFF
--- a/src/routes/room/[room=uuid]/ViewSchedule.svelte
+++ b/src/routes/room/[room=uuid]/ViewSchedule.svelte
@@ -1,23 +1,25 @@
 <script lang="ts">
-	import { isEqual } from 'lodash-es';
 	import ScheduleDisplay from './ScheduleDisplay.svelte';
 	import type { Schedule, Class } from '$lib/InfoInput';
 	import type { ResolvedYou } from './ViewSchedules';
+	import { isCurrentSchedule } from './schedule-order';
 	let {
 		schedule,
 		you,
 		getClass
 	}: { schedule: Schedule; you: ResolvedYou; getClass: (id: string) => Promise<Class> } = $props();
+	let isYou = $derived(isCurrentSchedule(schedule, you));
 </script>
 
 <div
-	class="my-3 collapse h-fit w-fit collapse-plus border border-base-300 bg-base-100 shadow-xl rounded-box"
+	class="my-3 collapse h-fit w-fit collapse-plus border bg-base-100 shadow-xl rounded-box {isYou
+		? 'border-primary bg-primary/10 ring-2 ring-primary/30'
+		: 'border-base-300'}"
+	data-current-user={isYou || undefined}
 >
 	<input type="checkbox" />
-	<div class="collapse-title text-xl font-medium">
-		{schedule.student}'s schedule {isEqual({ name: schedule.student, schedule }, you)
-			? '(you)'
-			: ''}
+	<div class="collapse-title text-xl font-medium" class:text-primary={isYou}>
+		{schedule.student}'s schedule {isYou ? '(you)' : ''}
 		<!-- TODO: Show if in common -->
 	</div>
 	<div class="collapse-content hidden">

--- a/src/routes/room/[room=uuid]/ViewSchedules.svelte
+++ b/src/routes/room/[room=uuid]/ViewSchedules.svelte
@@ -4,6 +4,7 @@
 	import type { Schedule, VirtualSchedule, Class } from '$lib/InfoInput';
 	import { copyToClipboard } from '$lib/actions';
 	import type { You } from './ViewSchedules';
+	import { prioritizeCurrentSchedule } from './schedule-order';
 	import Fuse from 'fuse.js';
 
 	let {
@@ -25,7 +26,12 @@
 	}
 	let searchQuery = $state('');
 	let fuse = $derived(new Fuse(schedules, { keys: ['student'] }));
-	let filtered = $derived(searchQuery ? fuse.search(searchQuery).map((x) => x.item) : schedules);
+	let filtered = $derived(
+		prioritizeCurrentSchedule(
+			searchQuery ? fuse.search(searchQuery).map((result) => result.item) : schedules,
+			you
+		)
+	);
 </script>
 
 <label class="input input-bordered flex items-center gap-2 w-96 mx-auto my-5">

--- a/src/routes/room/[room=uuid]/schedule-order.ts
+++ b/src/routes/room/[room=uuid]/schedule-order.ts
@@ -1,0 +1,19 @@
+import type { Schedule } from '$lib/InfoInput';
+import type { You } from './ViewSchedules';
+
+export function isCurrentSchedule(schedule: Schedule, you: You): boolean {
+	return you !== null && you !== 'tentative' && schedule.student === you.name;
+}
+
+export function prioritizeCurrentSchedule(schedules: Schedule[], you: You): Schedule[] {
+	const ordered = [...schedules];
+	const currentIndex = ordered.findIndex((schedule) => isCurrentSchedule(schedule, you));
+
+	if (currentIndex <= 0) {
+		return ordered;
+	}
+
+	const [current] = ordered.splice(currentIndex, 1);
+	ordered.unshift(current);
+	return ordered;
+}

--- a/tests/schedule-order.spec.ts
+++ b/tests/schedule-order.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+import type { Schedule } from '../src/lib/InfoInput';
+import type { You } from '../src/routes/room/[room=uuid]/ViewSchedules';
+import {
+	isCurrentSchedule,
+	prioritizeCurrentSchedule
+} from '../src/routes/room/[room=uuid]/schedule-order';
+
+const makeSchedule = (student: string): Schedule => ({
+	student,
+	room: 'room',
+	'1a': '1a',
+	'1b': '1b',
+	'2a': '2a',
+	'2b': '2b',
+	'3a': '3a',
+	'3b': '3b',
+	'4a': '4a',
+	'4b': '4b'
+});
+
+const ada = makeSchedule('Ada');
+const grace = makeSchedule('Grace');
+const linus = makeSchedule('Linus');
+const currentUser: You = { name: 'Grace', schedule: grace };
+
+test('moves the current user first without mutating the Supabase result', () => {
+	const schedules = [ada, grace, linus];
+	const ordered = prioritizeCurrentSchedule(schedules, currentUser);
+
+	expect(ordered).toEqual([grace, ada, linus]);
+	expect(schedules).toEqual([ada, grace, linus]);
+	expect(ordered).not.toBe(schedules);
+});
+
+test('preserves every other schedule order after search or matching filters', () => {
+	const filtered = [linus, ada, grace];
+
+	expect(prioritizeCurrentSchedule(filtered, currentUser)).toEqual([grace, linus, ada]);
+});
+
+test('keeps the current user first after realtime inserts', () => {
+	const schedules = [ada, grace];
+	const realtimeSchedules = [...schedules, linus];
+
+	expect(prioritizeCurrentSchedule(realtimeSchedules, currentUser)).toEqual([grace, ada, linus]);
+});
+
+test('restores source order when identity is reset or unresolved', () => {
+	const schedules = [ada, grace, linus];
+
+	expect(prioritizeCurrentSchedule(schedules, null)).toEqual(schedules);
+	expect(prioritizeCurrentSchedule(schedules, 'tentative')).toEqual(schedules);
+});
+
+test('uses the persisted student identity for current-user treatment', () => {
+	expect(isCurrentSchedule(grace, currentUser)).toBe(true);
+	expect(isCurrentSchedule(ada, currentUser)).toBe(false);
+});


### PR DESCRIPTION
## Summary

- move the current user's schedule to the front after search filtering without mutating Supabase results
- give the current-user card a primary-colored border, tint, ring, and title while preserving the existing `(you)` label
- cover source-order preservation, filtered results, realtime inserts, identity reset, and current-user detection

## Validation

- `PUBLIC_SUPABASE_URL=https://example.supabase.co PUBLIC_SUPABASE_ANON_KEY=test pnpm run test` (6 passed; includes production build)
- changed-file ESLint and Prettier checks
- `git diff --check`

## Notes

The full `pnpm run check` still reports pre-existing type errors in `src/lib/engineer.ts`; no diagnostics are reported in the changed files.

Closes #62
