### PR TITLE
Highlight shared classes scheduled in different periods

### DIFF
--- a/src/lib/scheduleComparison.ts
+++ b/src/lib/scheduleComparison.ts
@@ -1,0 +1,24 @@
+import type { VirtualSchedule } from '$lib/InfoInput.d';
+
+export const SCHEDULE_PERIODS = ['1a', '2a', '3a', '4a', '1b', '2b', '3b', '4b'] as const;
+
+export type SchedulePeriod = (typeof SCHEDULE_PERIODS)[number];
+export type ClassMatch = 'same-period' | 'different-period' | 'not-shared';
+
+export function getClassMatch(
+	theirSchedule: VirtualSchedule,
+	yourSchedule: VirtualSchedule,
+	period: SchedulePeriod
+): ClassMatch {
+	const classId = theirSchedule[period];
+
+	if (yourSchedule[period] === classId) {
+		return 'same-period';
+	}
+
+	if (SCHEDULE_PERIODS.some((yourPeriod) => yourSchedule[yourPeriod] === classId)) {
+		return 'different-period';
+	}
+
+	return 'not-shared';
+}

--- a/src/routes/room/[room=uuid]/ScheduleDisplay.svelte
+++ b/src/routes/room/[room=uuid]/ScheduleDisplay.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { titlecase } from '$lib/utils';
 	import type { VirtualSchedule, Class } from '$lib/InfoInput.d';
+	import { getClassMatch, type ClassMatch } from '$lib/scheduleComparison';
 	let {
 		them,
 		you,
@@ -10,7 +11,27 @@
 	const periods = [0, 1, 2, 3] as const;
 	const aDay = ['1a', '2a', '3a', '4a'] as const;
 	const bDay = ['1b', '2b', '3b', '4b'] as const;
+	const matchLabels: Record<ClassMatch, string> = {
+		'same-period': 'Same class, same period',
+		'different-period': 'Same class, different period',
+		'not-shared': 'Class not shared'
+	};
 </script>
+
+<div class="mb-2 flex flex-wrap gap-x-4 gap-y-2 text-sm" aria-label="Schedule comparison legend">
+	<span class="inline-flex items-center gap-2">
+		<span class="size-4 rounded bg-success" aria-hidden="true"></span>
+		{matchLabels['same-period']}
+	</span>
+	<span class="inline-flex items-center gap-2">
+		<span class="size-4 rounded bg-warning" aria-hidden="true"></span>
+		{matchLabels['different-period']}
+	</span>
+	<span class="inline-flex items-center gap-2">
+		<span class="size-4 rounded border border-base-300 bg-base-100" aria-hidden="true"></span>
+		{matchLabels['not-shared']}
+	</span>
+</div>
 
 <table class="table w-full">
 	<thead>
@@ -26,8 +47,8 @@
 			{@const scheduleB = them[bDay[period]]}
 			{@const classA = getClass(scheduleA)}
 			{@const classB = getClass(scheduleB)}
-			{@const aInCommon = you && you[aDay[period]] == scheduleA}
-			{@const bInCommon = you && you[bDay[period]] == scheduleB}
+			{@const aMatch = getClassMatch(them, you, aDay[period])}
+			{@const bMatch = getClassMatch(them, you, bDay[period])}
 			{@const resolved = Promise.all([classA, classB])}
 			{#await resolved then [classA, classB]}
 				<!-- row 1 -->
@@ -36,30 +57,38 @@
 					<td
 						><div
 							class="rounded-box p-2 py-3 w-fit"
-							class:bg-success={aInCommon}
-							class:text-success-content={aInCommon}
+							class:bg-success={aMatch === 'same-period'}
+							class:text-success-content={aMatch === 'same-period'}
+							class:bg-warning={aMatch === 'different-period'}
+							class:text-warning-content={aMatch === 'different-period'}
+							data-match={aMatch}
 						>
 							<span
 								>{titlecase(classA['name'])}
 								<span class="text-xs text-gray-500"
 									>{titlecase(classA['teacher_first'])}
 									{titlecase(classA['teacher_last'])}</span
-								></span
+								>
+								<span class="sr-only"> — {matchLabels[aMatch]}</span></span
 							>
 						</div></td
 					>
 					<td
 						><div
 							class="rounded-box p-2 py-3 w-fit"
-							class:bg-success={bInCommon}
-							class:text-success-content={bInCommon}
+							class:bg-success={bMatch === 'same-period'}
+							class:text-success-content={bMatch === 'same-period'}
+							class:bg-warning={bMatch === 'different-period'}
+							class:text-warning-content={bMatch === 'different-period'}
+							data-match={bMatch}
 						>
 							<span
 								>{titlecase(classB['name'])}
 								<span class="text-xs text-gray-500"
 									>{titlecase(classB['teacher_first'])}
 									{titlecase(classB['teacher_last'])}</span
-								></span
+								>
+								<span class="sr-only"> — {matchLabels[bMatch]}</span></span
 							>
 						</div></td
 					>

--- a/tests/schedule-comparison.spec.ts
+++ b/tests/schedule-comparison.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+import { getClassMatch, type SchedulePeriod } from '../src/lib/scheduleComparison';
+import type { VirtualSchedule } from '../src/lib/InfoInput.d';
+
+function schedule(overrides: Partial<Record<SchedulePeriod, string>> = {}): VirtualSchedule {
+	return {
+		'1a': 'algebra',
+		'2a': 'biology',
+		'3a': 'chemistry',
+		'4a': 'drama',
+		'1b': 'english',
+		'2b': 'french',
+		'3b': 'geometry',
+		'4b': 'history',
+		...overrides
+	};
+}
+
+test('marks a class in the same A-day period as a same-period match', () => {
+	const theirs = schedule();
+	const yours = schedule({ '2a': 'biology', '4a': 'biology' });
+
+	expect(getClassMatch(theirs, yours, '2a')).toBe('same-period');
+});
+
+test('checks the entire schedule for a class in a different A-day period', () => {
+	const theirs = schedule();
+	const yours = schedule({ '2a': 'calculus', '4b': 'biology' });
+
+	expect(getClassMatch(theirs, yours, '2a')).toBe('different-period');
+});
+
+test('checks the entire schedule for a class in a different B-day period', () => {
+	const theirs = schedule();
+	const yours = schedule({ '3b': 'art', '1a': 'geometry' });
+
+	expect(getClassMatch(theirs, yours, '3b')).toBe('different-period');
+});
+
+test('leaves a class unmarked when it is absent from the other schedule', () => {
+	const theirs = schedule();
+	const yours = schedule({ '1b': 'music' });
+
+	expect(getClassMatch(theirs, yours, '1b')).toBe('not-shared');
+});


### PR DESCRIPTION
## Summary

- classify each compared class as same period, different period, or not shared
- scan all eight A-day and B-day periods before applying the different-period state
- render different-period matches in yellow and add visible plus screen-reader comparison labels
- cover same-period precedence, cross-day schedule scans, and absent classes with focused tests

## Root cause

The schedule table only compared matching period keys, so it could identify same-period classes but never detect a class elsewhere in the other person's schedule.

## Verification

- `pnpm exec playwright test schedule-comparison.spec.ts --config playwright.unit.config.ts --reporter=line` (temporary no-web-server config; 4 passed)
- `PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 PUBLIC_SUPABASE_ANON_KEY=placeholder pnpm build`
- ESLint and Prettier checks for all changed files
- browser smoke test of the production preview: populated page, no error overlay, no page errors

The repository-wide `pnpm check` still reports two pre-existing type errors in `src/lib/engineer.ts`, unrelated to this change.

Closes #59
