### PR TITLE
Add Terms of Service and Privacy Policy

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,8 @@ dotenv.config();
 const config: PlaywrightTestConfig = {
 	webServer: {
 		command: 'pnpm run build && pnpm run preview',
-		port: 4173
+		port: 4173,
+		reuseExistingServer: !process.env.CI
 	}
 };
 

--- a/src/lib/ClassPicker.svelte
+++ b/src/lib/ClassPicker.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import Fuse from 'fuse.js';
 	import type { Class } from './InfoInput';
 	import { titlecase } from '$lib/utils';
@@ -118,6 +119,10 @@
 					</svg></button
 				></label
 			>
+			<p class="mt-2 text-sm opacity-70">
+				Creating a class publishes its name and teacher to everyone with the room link. See our
+				<a href={resolve('/privacy')} class="link">Privacy Policy</a>.
+			</p>
 		</div>
 		<ul class="menu h-60 overflow-hidden overflow-y-scroll flex-nowrap">
 			<li class="menu-title">Classes</li>

--- a/src/lib/InfoInput.svelte
+++ b/src/lib/InfoInput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import ClassPicker from './ClassPicker.svelte';
 	import type { UnfinishedSchedule, VirtualSchedule } from './InfoInput.d';
 	import type { Classes } from './InfoInput';
@@ -81,4 +82,9 @@
 
 <div class="form-control mt-6">
 	<button class="btn btn-primary" disabled={!isValid} onclick={submit}>Done</button>
+	<p class="mx-auto mt-3 max-w-md text-center text-sm opacity-70">
+		By submitting, you agree to the <a href={resolve('/terms')} class="link">Terms of Service</a>
+		and acknowledge the <a href={resolve('/privacy')} class="link">Privacy Policy</a>. Your name,
+		classes, and teachers will be visible to anyone with this room link.
+	</p>
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -80,10 +80,12 @@
 				<a href="https://github.com/ThatXliner/wuzursched/blob/main/LICENSE" class="link">AGPLv3</a>
 			</p>
 		</aside>
-		<nav class="flex gap-5">
+		<nav class="flex flex-wrap justify-center gap-x-5 gap-y-2">
 			<a href={resolve('/')} class="link link-hover">Home</a>
 			<a href={resolve('/create')} class="link link-hover">Create a room</a>
 			<a href={resolve('/credits')} class="link link-hover">Credits</a>
+			<a href={resolve('/terms')} class="link link-hover">Terms</a>
+			<a href={resolve('/privacy')} class="link link-hover">Privacy</a>
 			<a href="https://github.com/ThatXliner/wuzursched" class="link link-hover">Source code</a>
 		</nav>
 	</footer>

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+</script>
+
+<!-- Obtain appropriate legal review before treating this document as final. -->
+
+<svelte:head>
+	<title>Privacy Policy · Wuzursched</title>
+	<meta
+		name="description"
+		content="How Wuzursched collects, uses, shares, retains, and deletes information."
+	/>
+</svelte:head>
+
+<section class="ruled py-12 md:py-16">
+	<article class="mx-auto max-w-3xl px-6">
+		<header class="sketchy border-2 border-base-content/40 bg-base-100 p-6 shadow-sm md:p-8">
+			<p class="font-marker text-lg opacity-70">What Wuzursched knows and why</p>
+			<h1 class="mt-1 font-marker text-5xl font-bold md:text-6xl">Privacy Policy</h1>
+			<p class="mt-3 font-semibold">Effective July 14, 2026</p>
+		</header>
+
+		<div class="mt-8 space-y-8 rounded-box bg-base-100 p-6 shadow-sm md:p-10">
+			<section>
+				<h2 class="font-marker text-3xl font-bold">Overview</h2>
+				<p class="mt-2">
+					This Privacy Policy explains how Wuzursched collects, uses, discloses, and retains
+					information when you use the service. Wuzursched lets people share and compare class
+					schedules through link-accessible rooms without creating an account.
+				</p>
+				<div class="alert alert-warning mt-4">
+					<span>
+						<strong>Room links are sharing links.</strong> Anyone who has a room link may be able to read
+						the room’s contents. Do not put confidential or unnecessary personal information in a room.
+					</span>
+				</div>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">Information we collect</h2>
+				<h3 class="mt-3 text-2xl font-bold">Information submitted to rooms</h3>
+				<p class="mt-2">Depending on how you use Wuzursched, room data may include:</p>
+				<ul class="mt-2 list-disc space-y-1 pl-6">
+					<li>a room identifier and the time the room was created;</li>
+					<li>student names;</li>
+					<li>class names, periods, and schedule selections;</li>
+					<li>teachers’ first and last names; and</li>
+					<li>
+						account, administrator, ownership, or edit-capability identifiers if those features are
+						added in the future.
+					</li>
+				</ul>
+
+				<h3 class="mt-5 text-2xl font-bold">Information stored in your browser</h3>
+				<p class="mt-2">
+					Wuzursched uses local browser storage to remember which student identity and schedule you
+					selected for a room. It may also store room identity, ownership, or edit capabilities if
+					those features are added. You can remove local data through Wuzursched’s reset control or
+					by clearing site data in your browser. Clearing browser data does not delete information
+					already stored in a room.
+				</p>
+
+				<h3 class="mt-5 text-2xl font-bold">Cookies, logs, and technical information</h3>
+				<p class="mt-2">
+					Wuzursched and its service providers may use cookies or similar storage needed for
+					authentication, security, and core service operation. Supabase and Vercel may receive
+					technical information such as IP address, browser and device details, request URLs,
+					timestamps, errors, and security or diagnostic logs when they provide database, realtime,
+					authentication, hosting, and network services. Wuzursched does not currently use
+					advertising cookies or sell personal information.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">How we use information</h2>
+				<p class="mt-2">We use information to:</p>
+				<ul class="mt-2 list-disc space-y-1 pl-6">
+					<li>create rooms and display, compare, search, and update schedules in realtime;</li>
+					<li>remember your identity within a room on your device;</li>
+					<li>operate, troubleshoot, secure, maintain, and improve the service;</li>
+					<li>respond to questions, abuse reports, and deletion requests; and</li>
+					<li>comply with legal obligations and protect users and the service.</li>
+				</ul>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">How information is disclosed</h2>
+				<p class="mt-2">
+					<strong>People with a room link.</strong> Student names, classes, teachers, and schedules in
+					a room are visible to people who can access its link. A recipient may copy or share that information
+					outside Wuzursched, which we cannot control.
+				</p>
+				<p class="mt-3">
+					<strong>Service providers.</strong> Supabase processes and stores database, authentication,
+					and realtime data. Vercel hosts and delivers the application and may process request and diagnostic
+					logs. They process information to provide services to Wuzursched under their applicable terms
+					and privacy commitments.
+				</p>
+				<p class="mt-3">
+					<strong>Legal and safety reasons.</strong> We may preserve or disclose information when reasonably
+					necessary to comply with law, respond to valid legal process, investigate abuse, or protect
+					the rights, safety, and security of users, the public, or the service.
+				</p>
+				<p class="mt-3">
+					<strong>Organizational changes.</strong> If responsibility for Wuzursched is transferred, information
+					may be transferred with the service, subject to this Policy and applicable law.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">Retention and deletion</h2>
+				<p class="mt-2">
+					Room information is retained while the room remains available or as needed to operate,
+					secure, and comply with legal obligations for the service. Technical logs and backups may
+					remain for the periods set by Supabase, Vercel, or other infrastructure providers and may
+					not be removed immediately from backup systems.
+				</p>
+				<p class="mt-3">
+					To request deletion or correction, email
+					<a href="mailto:thatxliner@gmail.com" class="link">thatxliner@gmail.com</a> with the room link,
+					the student name or class involved, and enough information to identify the submission. Do not
+					email schedule details that are not needed for the request. We may ask for reasonable verification
+					and may retain information when required by law or needed for security and fraud prevention.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">Students and minors</h2>
+				<p class="mt-2">
+					Wuzursched is designed for sharing school schedules, so submitted information may concern
+					students who are minors. The service is not directed to children under 13, and information
+					about children under 13 should not be submitted. Minors should use the service only with
+					the permission and supervision required by a parent, guardian, or school. Schools,
+					teachers, and other organizers should obtain any required consent and complete their own
+					privacy and legal review before asking students to use Wuzursched.
+				</p>
+				<p class="mt-3">
+					If you believe a child under 13 has provided personal information, or you are a parent or
+					guardian requesting access, correction, or deletion for a minor, contact us at
+					<a href="mailto:thatxliner@gmail.com" class="link">thatxliner@gmail.com</a>.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">Security and international processing</h2>
+				<p class="mt-2">
+					We use reasonable measures intended to protect the service, but no storage or transmission
+					method is completely secure. Information may be processed in locations where Wuzursched,
+					Supabase, Vercel, or their service providers operate, which may be outside your state,
+					province, or country.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">Changes to this policy</h2>
+				<p class="mt-2">
+					We may update this Policy as Wuzursched changes. We will post the updated version on this
+					page and revise the effective date. Material changes may also be communicated through the
+					service when appropriate.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">Contact</h2>
+				<p class="mt-2">
+					For privacy questions or requests, email
+					<a href="mailto:thatxliner@gmail.com" class="link">thatxliner@gmail.com</a>. Questions
+					about using the service are also governed by the
+					<a href={resolve('/terms')} class="link">Terms of Service</a>.
+				</p>
+			</section>
+		</div>
+	</article>
+</section>

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+</script>
+
+<!-- Obtain appropriate legal review before treating this document as final. -->
+
+<svelte:head>
+	<title>Terms of Service · Wuzursched</title>
+	<meta
+		name="description"
+		content="Terms governing access to and use of the Wuzursched schedule-sharing service."
+	/>
+</svelte:head>
+
+<section class="ruled py-12 md:py-16">
+	<article class="mx-auto max-w-3xl px-6">
+		<header class="sketchy border-2 border-base-content/40 bg-base-100 p-6 shadow-sm md:p-8">
+			<p class="font-marker text-lg opacity-70">The rules for using Wuzursched</p>
+			<h1 class="mt-1 font-marker text-5xl font-bold md:text-6xl">Terms of Service</h1>
+			<p class="mt-3 font-semibold">Effective July 14, 2026</p>
+		</header>
+
+		<div class="mt-8 space-y-8 rounded-box bg-base-100 p-6 shadow-sm md:p-10">
+			<section>
+				<h2 class="font-marker text-3xl font-bold">1. Agreement to these terms</h2>
+				<p class="mt-2">
+					These Terms of Service (the “Terms”) govern your access to and use of Wuzursched. By
+					accessing or using the service, creating a room, or submitting information, you agree to
+					these Terms and acknowledge our <a href={resolve('/privacy')} class="link"
+						>Privacy Policy</a
+					>. If you do not agree, do not use the service.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">2. Who may use Wuzursched</h2>
+				<p class="mt-2">
+					You must be able to agree to these Terms under the laws that apply to you. Wuzursched is
+					not directed to children under 13, and children under 13 may not use the service or have
+					personal information submitted about them. If you are a minor, use Wuzursched only with
+					the permission and supervision required from a parent, guardian, or school.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">3. Rooms and shared links</h2>
+				<p class="mt-2">
+					Rooms are accessed through unique links rather than private accounts. A room link is not a
+					password. Anyone who receives or discovers a room link may be able to read the room’s
+					contents, including student names, class names, teachers, and schedules. Share links only
+					with people you trust and submit only information you are comfortable sharing with that
+					audience.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">4. Your submissions</h2>
+				<p class="mt-2">
+					You keep any rights you have in information you submit. You give Wuzursched permission to
+					host, store, reproduce, display, and transmit that information only as needed to operate,
+					secure, and improve the service. You are responsible for your submissions and must have
+					permission to share information about other people, including students and teachers.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">5. Acceptable use</h2>
+				<p class="mt-2">You may not use Wuzursched to:</p>
+				<ul class="mt-2 list-disc space-y-1 pl-6">
+					<li>break the law or violate another person’s rights;</li>
+					<li>submit information you do not have permission to share;</li>
+					<li>harass, impersonate, threaten, or harm another person;</li>
+					<li>post sensitive information that is not needed to compare class schedules;</li>
+					<li>probe, disrupt, overload, or bypass the service’s security or access controls; or</li>
+					<li>use automated means to scrape rooms or collect information about other people.</li>
+				</ul>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">6. Service changes and enforcement</h2>
+				<p class="mt-2">
+					We may change, suspend, or discontinue any part of Wuzursched. We may remove content,
+					restrict access, or take other reasonable action when we believe these Terms, the law, or
+					the safety of users requires it. The service may occasionally be unavailable or lose
+					functionality, and we do not promise that any room or submission will remain available.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">7. Third-party services</h2>
+				<p class="mt-2">
+					Wuzursched relies on third-party services, including Supabase for database,
+					authentication, and realtime features and Vercel for hosting. Those providers may process
+					information as described in the Privacy Policy and under their own terms and policies.
+					Links to other websites do not mean we control or endorse them.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">8. Disclaimers</h2>
+				<p class="mt-2">
+					Wuzursched is provided “as is” and “as available.” To the fullest extent permitted by law,
+					we disclaim warranties of merchantability, fitness for a particular purpose,
+					non-infringement, availability, accuracy, and security. Wuzursched is a convenience for
+					sharing schedules; it is not an official school record or a substitute for information
+					from a school.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">9. Limitation of liability</h2>
+				<p class="mt-2">
+					To the fullest extent permitted by law, Wuzursched and its maintainers will not be liable
+					for indirect, incidental, special, consequential, exemplary, or punitive damages, or for
+					lost data, use, goodwill, or profits arising from the service. Nothing in these Terms
+					excludes liability that cannot lawfully be excluded.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">10. Changes to these terms</h2>
+				<p class="mt-2">
+					We may update these Terms as the service changes. We will post the updated version here
+					and change the effective date. Your continued use after an update means you accept the
+					revised Terms to the extent allowed by law.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="font-marker text-3xl font-bold">11. Contact</h2>
+				<p class="mt-2">
+					Questions about these Terms may be sent to
+					<a href="mailto:thatxliner@gmail.com" class="link">thatxliner@gmail.com</a>.
+				</p>
+			</section>
+		</div>
+	</article>
+</section>

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -4,3 +4,37 @@ test('index page has expected h1', async ({ page }) => {
 	await page.goto('/');
 	expect(await page.textContent('h1')).toBe('Wuzursched');
 });
+
+test('footer links to the legal documents', async ({ page }) => {
+	await page.goto('/');
+
+	await expect(page.getByRole('contentinfo').getByRole('link', { name: 'Terms' })).toHaveAttribute(
+		'href',
+		'/terms'
+	);
+	await expect(
+		page.getByRole('contentinfo').getByRole('link', { name: 'Privacy' })
+	).toHaveAttribute('href', '/privacy');
+});
+
+test('terms of service is available at a durable route', async ({ page }) => {
+	await page.goto('/terms');
+
+	await expect(page).toHaveTitle(/Terms of Service/);
+	await expect(page.getByRole('heading', { level: 1 })).toHaveText('Terms of Service');
+	await expect(page.getByText('Effective July 14, 2026')).toBeVisible();
+	await expect(page.getByRole('link', { name: 'thatxliner@gmail.com' })).toHaveAttribute(
+		'href',
+		'mailto:thatxliner@gmail.com'
+	);
+});
+
+test('privacy policy describes room visibility and deletion', async ({ page }) => {
+	await page.goto('/privacy');
+
+	await expect(page).toHaveTitle(/Privacy Policy/);
+	await expect(page.getByRole('heading', { level: 1 })).toHaveText('Privacy Policy');
+	await expect(page.getByText('Effective July 14, 2026')).toBeVisible();
+	await expect(page.getByText(/Anyone who has a room link may be able to read/)).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Retention and deletion' })).toBeVisible();
+});


### PR DESCRIPTION
## Summary

- add durable `/terms` and `/privacy` routes with an effective date and contact method
- document room data, browser storage, link-based visibility, Supabase/Vercel processing, cookies/logs, retention/deletion, and student/minor handling
- link both policies from the footer and add notice at schedule and class submission points
- add Playwright coverage for legal routes, metadata, contact details, visibility/deletion language, and footer links
- make local Playwright runs reuse an existing preview server while CI continues to start a fresh server

## Validation

- `PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm run build`
- `PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm exec playwright test` (4 passed)
- `pnpm exec eslint .`
- Prettier check for all changed files

## Legal review

The policy source includes a reminder that appropriate legal review is required before these documents are treated as final, as requested by the issue.

Closes #32
