### PR TITLE
Implement schedule engineering helper

### DIFF
--- a/src/lib/engineer.ts
+++ b/src/lib/engineer.ts
@@ -1,106 +1,277 @@
-// Implements the schedule engineering algorithm
+import type { VirtualSchedule } from './InfoInput.d';
 
-import { sum } from 'lodash-es';
-import { type VirtualSchedule, PERIODS, type UnfinishedSchedule } from './InfoInput.d';
-import { setDifference, type ArrElement } from './utils';
-function scheduleToClassSet(schedule: VirtualSchedule) {
-	const classSet = new Set<string>();
-	for (const time of Object.keys(schedule)) {
-		const className = schedule[time as keyof VirtualSchedule];
-		if (className) {
-			classSet.add(className);
+export const PERIODS = ['1a', '1b', '2a', '2b', '3a', '3b', '4a', '4b'] as const;
+
+export type Period = (typeof PERIODS)[number];
+
+export type ScheduleLocks = {
+	periods?: Iterable<Period>;
+	classes?: Iterable<string>;
+};
+
+export type EngineerInput = {
+	student: string;
+	schedule: VirtualSchedule;
+	locks?: ScheduleLocks;
+};
+
+export type ScheduleMove = {
+	classId: string;
+	from: Period;
+	to: Period;
+};
+
+export type EngineeredSchedule = {
+	student: string;
+	original: VirtualSchedule;
+	proposed: VirtualSchedule;
+	moves: ScheduleMove[];
+};
+
+export type EngineerResult =
+	| { status: 'empty' }
+	| { status: 'no-solution'; reason: string }
+	| {
+			status: 'success';
+			anchor: string;
+			sharedPlacements: number;
+			movementCost: number;
+			schedules: EngineeredSchedule[];
+	  };
+
+type NormalizedLocks = {
+	periods: Set<Period>;
+	classes: Set<string>;
+};
+
+type ScheduleItem = {
+	id: number;
+	classId: string;
+	originalPeriod: Period;
+};
+
+function normalizedLocks(locks?: ScheduleLocks): NormalizedLocks {
+	return {
+		periods: new Set(locks?.periods ?? []),
+		classes: new Set(locks?.classes ?? [])
+	};
+}
+
+function classPeriods(schedule: VirtualSchedule): Map<string, Period> {
+	const result = new Map<string, Period>();
+	for (const period of PERIODS) {
+		const classId = schedule[period];
+		if (classId) result.set(classId, period);
+	}
+	return result;
+}
+
+function validateInput(input: EngineerInput): string | undefined {
+	const seen = new Set<string>();
+	for (const period of PERIODS) {
+		const classId = input.schedule[period];
+		if (!classId) continue;
+		if (seen.has(classId)) {
+			return `${input.student}'s schedule contains the same class more than once.`;
+		}
+		seen.add(classId);
+	}
+
+	const locks = normalizedLocks(input.locks);
+	for (const period of locks.periods) {
+		if (!PERIODS.includes(period)) return `${input.student} has an unknown locked period.`;
+	}
+	for (const classId of locks.classes) {
+		if (!seen.has(classId)) return `${input.student} has a lock for a class not in their schedule.`;
+	}
+	return undefined;
+}
+
+function* anchorCandidates(input: EngineerInput): Generator<VirtualSchedule> {
+	const locks = normalizedLocks(input.locks);
+	const items: ScheduleItem[] = PERIODS.map((period, id) => ({
+		id,
+		classId: input.schedule[period] ?? '',
+		originalPeriod: period
+	}));
+	const fixedByPeriod = new Map<Period, ScheduleItem>();
+	const fixedIds = new Set<number>();
+
+	for (const item of items) {
+		if (
+			locks.periods.has(item.originalPeriod) ||
+			(item.classId && locks.classes.has(item.classId))
+		) {
+			fixedByPeriod.set(item.originalPeriod, item);
+			fixedIds.add(item.id);
 		}
 	}
-	return classSet;
-}
-function findCommonClasses(schedules: VirtualSchedule[]) {
-	const classSets = schedules.map(scheduleToClassSet);
-	const commonClasses = new Set<string>();
-	for (const className of classSets) {
-		if (classSets.every((classSet) => classSet.has(className))) {
-			commonClasses.add(className);
+
+	const built: Partial<VirtualSchedule> = {};
+	const used = new Set<number>();
+	function* visit(index: number): Generator<VirtualSchedule> {
+		if (index === PERIODS.length) {
+			yield { ...built } as VirtualSchedule;
+			return;
+		}
+
+		const period = PERIODS[index];
+		const fixed = fixedByPeriod.get(period);
+		if (fixed) {
+			built[period] = fixed.classId;
+			used.add(fixed.id);
+			yield* visit(index + 1);
+			used.delete(fixed.id);
+			return;
+		}
+
+		// Empty slots are interchangeable. Avoid emitting the same incomplete schedule repeatedly.
+		const valuesTried = new Set<string>();
+		for (const item of items) {
+			if (used.has(item.id) || fixedIds.has(item.id) || valuesTried.has(item.classId)) continue;
+			valuesTried.add(item.classId);
+			built[period] = item.classId;
+			used.add(item.id);
+			yield* visit(index + 1);
+			used.delete(item.id);
 		}
 	}
-	return commonClasses;
+
+	yield* visit(0);
 }
-// A heuristic to determine how much two schedules differ
-// (you should be minimizing this)
-function scheduleMovementHeuristic(a: VirtualSchedule, b: VirtualSchedule) {
-	return Object.entries(a).filter(([key, value]) => value !== b[key as keyof VirtualSchedule])
+
+function buildFriendProposal(input: EngineerInput, anchor: VirtualSchedule): VirtualSchedule {
+	const locks = normalizedLocks(input.locks);
+	const originalPeriods = classPeriods(input.schedule);
+	const proposed: Partial<VirtualSchedule> = {};
+	const placed = new Set<string>();
+
+	// Period and class locks both pin the current value to its original period.
+	for (const period of PERIODS) {
+		const classId = input.schedule[period];
+		if (locks.periods.has(period) || (classId && locks.classes.has(classId))) {
+			proposed[period] = classId;
+			if (classId) placed.add(classId);
+		}
+	}
+
+	// Every feasible anchor match is independent: anchor classes occupy distinct target periods.
+	for (const period of PERIODS) {
+		const classId = anchor[period];
+		if (!classId || placed.has(classId) || !originalPeriods.has(classId)) continue;
+		const originalPeriod = originalPeriods.get(classId)!;
+		if (locks.classes.has(classId) && originalPeriod !== period) continue;
+		if (proposed[period] !== undefined && proposed[period] !== classId) continue;
+		proposed[period] = classId;
+		placed.add(classId);
+	}
+
+	// Preserve every remaining class that can stay put. This minimizes movement after matches.
+	for (const period of PERIODS) {
+		const classId = input.schedule[period];
+		if (classId && !placed.has(classId) && proposed[period] === undefined) {
+			proposed[period] = classId;
+			placed.add(classId);
+		}
+	}
+
+	// Any still-displaced classes have equal movement cost. Sort them for deterministic tie-breaking.
+	const remainingClasses = [...originalPeriods.keys()].filter((id) => !placed.has(id)).sort();
+	const remainingPeriods = PERIODS.filter((period) => proposed[period] === undefined);
+	for (let index = 0; index < remainingPeriods.length; index += 1) {
+		proposed[remainingPeriods[index]] = remainingClasses[index] ?? '';
+	}
+	return proposed as VirtualSchedule;
+}
+
+function movesBetween(original: VirtualSchedule, proposed: VirtualSchedule): ScheduleMove[] {
+	const proposedPeriods = classPeriods(proposed);
+	const moves: ScheduleMove[] = [];
+	for (const from of PERIODS) {
+		const classId = original[from];
+		if (!classId) continue;
+		const to = proposedPeriods.get(classId)!;
+		if (from !== to) moves.push({ classId, from, to });
+	}
+	return moves;
+}
+
+function countShared(anchor: VirtualSchedule, friend: VirtualSchedule): number {
+	return PERIODS.filter((period) => Boolean(anchor[period]) && anchor[period] === friend[period])
 		.length;
 }
-// Maximize the chance of having a common class for all schedules
-// e.g. if we all have the same math class, move the math class to the same time
-// and if only my friend and I have the D&A class,
-// still move the D&A class to the same time as he does.
-// TODO: In the future, we will respect the restrictions of which
-// periods each class can be in
+
+function proposalKey(proposals: VirtualSchedule[]): string {
+	return proposals
+		.flatMap((schedule) => PERIODS.map((period) => schedule[period] ?? ''))
+		.join('\u0000');
+}
+
+/**
+ * Produces a proposal without mutating any input schedule.
+ *
+ * Objective, in order:
+ * 1. Maximize class/period matches between the first selected student (the anchor) and every friend.
+ * 2. Minimize the total number of classes moved from their original period.
+ * 3. Choose the lexicographically smallest proposal, making ties deterministic.
+ */
+export function engineerSchedules(inputs: EngineerInput[]): EngineerResult {
+	if (inputs.length === 0) return { status: 'empty' };
+	for (const input of inputs) {
+		const error = validateInput(input);
+		if (error) return { status: 'no-solution', reason: error };
+	}
+
+	let best:
+		| { sharedPlacements: number; movementCost: number; proposals: VirtualSchedule[]; key: string }
+		| undefined;
+
+	for (const anchor of anchorCandidates(inputs[0])) {
+		const proposals = [
+			anchor,
+			...inputs.slice(1).map((input) => buildFriendProposal(input, anchor))
+		];
+		const sharedPlacements = proposals
+			.slice(1)
+			.reduce((total, proposal) => total + countShared(anchor, proposal), 0);
+		const movementCost = proposals.reduce(
+			(total, proposal, index) => total + movesBetween(inputs[index].schedule, proposal).length,
+			0
+		);
+		const key = proposalKey(proposals);
+
+		if (
+			!best ||
+			sharedPlacements > best.sharedPlacements ||
+			(sharedPlacements === best.sharedPlacements && movementCost < best.movementCost) ||
+			(sharedPlacements === best.sharedPlacements &&
+				movementCost === best.movementCost &&
+				key < best.key)
+		) {
+			best = { sharedPlacements, movementCost, proposals, key };
+		}
+	}
+
+	if (!best)
+		return { status: 'no-solution', reason: 'The locked constraints cannot be satisfied.' };
+	return {
+		status: 'success',
+		anchor: inputs[0].student,
+		sharedPlacements: best.sharedPlacements,
+		movementCost: best.movementCost,
+		schedules: inputs.map((input, index) => ({
+			student: input.student,
+			original: input.schedule,
+			proposed: best!.proposals[index],
+			moves: movesBetween(input.schedule, best!.proposals[index])
+		}))
+	};
+}
+
+// Kept as a small compatibility wrapper for callers of the original unfinished helper.
 export function findOptimumSchedules(schedules: VirtualSchedule[]): VirtualSchedule[] {
-	const commonClasses = findCommonClasses(schedules);
-	function cost(schedule: VirtualSchedule) {
-		return sum(schedules.map((x) => scheduleMovementHeuristic(schedule, x)));
-	}
-	const cache: Record<string, VirtualSchedule> = {};
-	// Build the common schedule (leaving uncommon classes as blank)
-	// with the least amount of movement from the original schedules
-	function dpBuildCommonSchedule(
-		builtSoFar: UnfinishedSchedule,
-		period: ArrElement<typeof PERIODS>
-	): VirtualSchedule {
-		const classesLeft = setDifference(commonClasses, Object.values(builtSoFar));
-		const key = JSON.stringify({ classesLeft: [...classesLeft], period });
-		if (cache[key]) {
-			return cache[key];
-		}
-		if (period === PERIODS[PERIODS.length - 1]) {
-			if (classesLeft.size === 1) {
-				return (cache[key] = { ...builtSoFar, [period]: [...classesLeft][0] } as VirtualSchedule);
-			} else if (classesLeft.size === 0) {
-				return (cache[key] = builtSoFar as VirtualSchedule);
-			} else {
-				throw new Error('Impossible to build common schedule');
-			}
-		}
-		let bestScheduleSoFar;
-		let minDistance;
-		if (PERIODS.indexOf(period) === PERIODS.length - classesLeft.size) {
-			// Don't leave it blank
-			minDistance = Number.POSITIVE_INFINITY;
-		} else {
-			if (PERIODS.indexOf(period) > PERIODS.length - classesLeft.size) {
-				throw new Error('Impossible.');
-			}
-			// Try leaving it blank
-			bestScheduleSoFar = dpBuildCommonSchedule(builtSoFar, PERIODS[PERIODS.indexOf(period) + 1]);
-			minDistance = cost(bestScheduleSoFar);
-		}
-		for (const classLeft of classesLeft) {
-			const newSchedule = { ...builtSoFar, [period]: classLeft };
-			const nextPeriod = PERIODS[PERIODS.indexOf(period) + 1];
-
-			const candidate = dpBuildCommonSchedule(newSchedule, nextPeriod);
-			const distance = cost(candidate);
-
-			if (distance < minDistance) {
-				minDistance = distance;
-				bestScheduleSoFar = candidate;
-			}
-		}
-		return (cache[key] = bestScheduleSoFar as VirtualSchedule);
-	}
-	const commonSchedule = dpBuildCommonSchedule({}, PERIODS[0]);
-	// Fill in the blanks left by common schedule for every student
-	// with the remaining classes of the student
-	return schedules.map((schedule) => {
-		// Shallow copy to avoid any reference issues
-		const filledSchedule = { ...commonSchedule };
-		const classesLeft = setDifference(new Set(Object.values(schedule)), commonClasses);
-		for (const time of Object.keys(schedule)) {
-			if (filledSchedule[time as keyof VirtualSchedule] == undefined) {
-				filledSchedule[time as keyof VirtualSchedule] = [...classesLeft][0];
-				classesLeft.delete([...classesLeft][0]);
-			}
-		}
-		return filledSchedule;
-	});
+	const result = engineerSchedules(
+		schedules.map((schedule, index) => ({ student: `Student ${index + 1}`, schedule }))
+	);
+	return result.status === 'success' ? result.schedules.map(({ proposed }) => proposed) : [];
 }

--- a/src/routes/room/[room=uuid]/+page.svelte
+++ b/src/routes/room/[room=uuid]/+page.svelte
@@ -259,7 +259,7 @@
 		<Tabs.List class="grid w-3/4 mx-auto grid-cols-3">
 			<Tabs.Trigger value="schedules">All Schedules</Tabs.Trigger>
 			<Tabs.Trigger value="filter">Filter</Tabs.Trigger>
-			<Tabs.Trigger value="engineer" disabled>Schedule Engineer (coming soon!)</Tabs.Trigger>
+			<Tabs.Trigger value="engineer">Schedule Engineer</Tabs.Trigger>
 		</Tabs.List>
 	{/if}
 	<Tabs.Content value="schedules">
@@ -271,7 +271,7 @@
 		{/if}
 	</Tabs.Content>
 	<Tabs.Content value="engineer">
-		<Engineer {schedules} />
+		<Engineer {schedules} {getClass} />
 	</Tabs.Content>
 </Tabs.Root>
 

--- a/src/routes/room/[room=uuid]/Engineer.svelte
+++ b/src/routes/room/[room=uuid]/Engineer.svelte
@@ -1,79 +1,250 @@
 <script lang="ts">
-	import type { Schedule } from '$lib/InfoInput';
-	import Fuse from 'fuse.js';
-	import { findOptimumSchedules } from '$lib/engineer';
+	import type { Class, Schedule } from '$lib/InfoInput';
+	import { engineerSchedules, PERIODS, type Period, type ScheduleLocks } from '$lib/engineer';
+	import { titlecase } from '$lib/utils';
 
-	let { schedules }: { schedules: Schedule[] } = $props();
-	let searchQuery = $state('');
-	let students: Schedule[] = $state([]);
-	let fuse = $derived(new Fuse(schedules, { keys: ['student'] }));
-	let filtered = $derived(searchQuery ? fuse.search(searchQuery).map((x) => x.item) : schedules);
-	let found = $derived(filtered.length === 1);
-	$effect(() => {
-		console.log(findOptimumSchedules(students));
-	});
+	let { schedules, getClass }: { schedules: Schedule[]; getClass: (id: string) => Promise<Class> } =
+		$props();
+	let selected: Schedule[] = $state([]);
+	let studentToAdd = $state('');
+	let locksByStudent: Record<string, { periods: Period[]; classes: string[] }> = $state({});
+
+	let available = $derived(
+		schedules.filter((schedule) => !selected.some((x) => x.student === schedule.student))
+	);
+	let result = $derived(
+		engineerSchedules(
+			selected.map((schedule) => ({
+				student: schedule.student,
+				schedule,
+				locks: locksByStudent[schedule.student] satisfies ScheduleLocks | undefined
+			}))
+		)
+	);
+	let hasIncompleteSchedule = $derived(
+		selected.some((schedule) => PERIODS.some((period) => !schedule[period]))
+	);
+
+	function addStudent() {
+		const schedule = schedules.find((candidate) => candidate.student === studentToAdd);
+		if (!schedule || selected.some((candidate) => candidate.student === schedule.student)) return;
+		selected = [...selected, schedule];
+		studentToAdd = '';
+	}
+
+	function removeStudent(student: string) {
+		selected = selected.filter((schedule) => schedule.student !== student);
+		const remainingLocks = { ...locksByStudent };
+		delete remainingLocks[student];
+		locksByStudent = remainingLocks;
+	}
+
+	function toggleLock(student: string, kind: 'periods' | 'classes', value: string) {
+		const current = locksByStudent[student] ?? { periods: [], classes: [] };
+		const values = current[kind] as string[];
+		const nextValues = values.includes(value)
+			? values.filter((candidate) => candidate !== value)
+			: [...values, value];
+		locksByStudent = {
+			...locksByStudent,
+			[student]: { ...current, [kind]: nextValues }
+		};
+	}
+
+	function isLocked(student: string, kind: 'periods' | 'classes', value: string) {
+		return (locksByStudent[student]?.[kind] as string[] | undefined)?.includes(value) ?? false;
+	}
 </script>
 
-<div class="flex justify-center">
-	<div>
-		<h2 class="text-5xl">Schedule Engineer: V1</h2>
-		<p class="w-96 my-2">
-			The schedule engineer allows you to figure out the steps required to have all of you and your
-			friends to share as many classes as possible
+<section class="mx-auto w-11/12 max-w-6xl py-8">
+	<header class="mb-6 text-center">
+		<h2 class="font-marker text-4xl font-bold md:text-5xl">Schedule Engineer</h2>
+		<p class="mx-auto mt-3 max-w-3xl opacity-75">
+			Choose an anchor student and friends, then preview the fewest schedule moves needed to
+			maximize the classes they can share. This is a planning tool: stored schedules are never
+			changed.
 		</p>
-		<p class="w-96 mb-5">
-			Future versions of Wuzursched Schedule Engineer will have pipeline-like features (via <a
-				href="https://retejs.org/"
-				class="link">Rete.js</a
-			>)
-		</p>
-	</div>
-</div>
-<div class="w-3/4 mx-auto bg-base-200 rounded-box p-5 shadow-lg">
-	<div class="dropdown">
-		<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-		<div class="join" tabindex="0">
-			<label class="input input-bordered flex items-center gap-2 join-item">
-				<input type="text" class="grow" placeholder="Search" bind:value={searchQuery} />
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					viewBox="0 0 16 16"
-					fill="currentColor"
-					class="h-4 w-4 opacity-70"
-				>
-					<path
-						fill-rule="evenodd"
-						d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z"
-						clip-rule="evenodd"
-					/>
-				</svg>
-			</label>
-			<button
-				class="btn btn-primary join-item"
-				disabled={!found}
-				onclick={() => {
-					students = [...students, filtered[0]];
-					searchQuery = '';
-				}}>Add Student</button
+	</header>
+
+	<div class="rounded-box border border-base-300 bg-base-200 p-4 shadow-sm">
+		<label class="mb-2 block font-semibold" for="engineer-student">Add a student</label>
+		<div class="flex flex-col gap-2 sm:flex-row">
+			<select
+				id="engineer-student"
+				class="select select-bordered grow"
+				bind:value={studentToAdd}
+				disabled={available.length === 0}
+			>
+				<option value="">{available.length ? 'Choose a student…' : 'Everyone is selected'}</option>
+				{#each available as schedule (schedule.student)}
+					<option value={schedule.student}>{schedule.student}</option>
+				{/each}
+			</select>
+			<button class="btn btn-primary" disabled={!studentToAdd} onclick={addStudent}
+				>Add student</button
 			>
 		</div>
-		<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-		<ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
-			{#each filtered as schedule (schedule.student)}
-				<li>
-					<span
-						onclick={() => {
-							searchQuery = schedule.student;
-						}}>{schedule.student}</span
-					>
-				</li>
-			{:else}
-				<p class="p-3">No results found</p>
-			{/each}
-		</ul>
+		<p class="mt-2 text-sm opacity-70">
+			The first student is the anchor. We maximize their shared placements with everyone else, then
+			minimize total moves; exact ties use a stable alphabetical ordering.
+		</p>
 	</div>
-</div>
-<div>
-	<p>{JSON.stringify(students)}</p>
-	<!-- <ViewSchedule {students} /> -->
-</div>
+
+	{#if selected.length === 0}
+		<div class="alert mt-6">
+			<span>Select at least one student to start building a proposal.</span>
+		</div>
+	{:else}
+		{#if hasIncompleteSchedule}
+			<div class="alert alert-warning mt-6">
+				<span
+					>Incomplete schedules are included; empty periods remain available for moved classes.</span
+				>
+			</div>
+		{/if}
+
+		<div class="mt-6 space-y-4">
+			{#each selected as schedule, index (schedule.student)}
+				<article class="rounded-box border border-base-300 bg-base-100 p-4 shadow-sm">
+					<div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+						<h3 class="text-2xl font-bold">
+							{schedule.student}
+							{#if index === 0}<span class="badge badge-primary align-middle">Anchor</span>{/if}
+						</h3>
+						<button
+							class="btn btn-sm btn-error btn-outline"
+							onclick={() => removeStudent(schedule.student)}
+						>
+							Remove
+						</button>
+					</div>
+					<p class="mb-3 text-sm opacity-70">
+						Lock a period to keep its current slot unchanged, or lock a class so that class cannot
+						move.
+					</p>
+					<div class="overflow-x-auto">
+						<table class="table table-sm">
+							<thead
+								><tr
+									><th>Period</th><th>Current class</th><th>Lock period</th><th>Lock class</th></tr
+								></thead
+							>
+							<tbody>
+								{#each PERIODS as period (period)}
+									{@const classId = schedule[period]}
+									<tr>
+										<th>{period.toUpperCase()}</th>
+										<td>
+											{#if classId}
+												{#await getClass(classId)}
+													<span class="loading loading-dots loading-xs"></span>
+												{:then resolvedClass}
+													{titlecase(resolvedClass.name)}
+												{:catch}
+													<span class="font-mono text-xs">{classId}</span>
+												{/await}
+											{:else}<span class="opacity-50">Empty</span>{/if}
+										</td>
+										<td>
+											<input
+												type="checkbox"
+												class="checkbox checkbox-sm"
+												aria-label={`Lock ${schedule.student}'s ${period.toUpperCase()} period`}
+												checked={isLocked(schedule.student, 'periods', period)}
+												onchange={() => toggleLock(schedule.student, 'periods', period)}
+											/>
+										</td>
+										<td>
+											<input
+												type="checkbox"
+												class="checkbox checkbox-sm"
+												aria-label={`Lock ${schedule.student}'s class in ${period.toUpperCase()}`}
+												disabled={!classId}
+												checked={Boolean(classId) && isLocked(schedule.student, 'classes', classId)}
+												onchange={() => classId && toggleLock(schedule.student, 'classes', classId)}
+											/>
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				</article>
+			{/each}
+		</div>
+
+		{#if result.status === 'no-solution'}
+			<div class="alert alert-error mt-6">
+				<span>No proposal is possible: {result.reason}</span>
+			</div>
+		{:else if result.status === 'success'}
+			<section class="mt-8" aria-live="polite">
+				<h3 class="font-marker text-3xl font-bold">Proposed schedules</h3>
+				<div
+					class="stats stats-vertical mt-3 w-full border border-base-300 shadow sm:stats-horizontal"
+				>
+					<div class="stat">
+						<div class="stat-title">Shared placements</div>
+						<div class="stat-value text-primary">{result.sharedPlacements}</div>
+						<div class="stat-desc">Anchor-to-friend class matches</div>
+					</div>
+					<div class="stat">
+						<div class="stat-title">Movement cost</div>
+						<div class="stat-value">{result.movementCost}</div>
+						<div class="stat-desc">One point per class moved</div>
+					</div>
+				</div>
+
+				<div class="mt-5 grid gap-4 lg:grid-cols-2">
+					{#each result.schedules as proposal (proposal.student)}
+						<article class="rounded-box border border-base-300 bg-base-100 p-4 shadow-sm">
+							<h4 class="text-xl font-bold">{proposal.student}</h4>
+							<div class="mt-2 overflow-x-auto">
+								<table class="table table-sm">
+									<thead><tr><th>Period</th><th>Proposed class</th></tr></thead>
+									<tbody>
+										{#each PERIODS as period (period)}
+											{@const classId = proposal.proposed[period]}
+											<tr class:bg-warning={classId !== proposal.original[period]}>
+												<th>{period.toUpperCase()}</th>
+												<td>
+													{#if classId}
+														{#await getClass(classId)}
+															<span class="loading loading-dots loading-xs"></span>
+														{:then resolvedClass}
+															{titlecase(resolvedClass.name)}
+														{:catch}<span class="font-mono text-xs">{classId}</span>{/await}
+													{:else}<span class="opacity-50">Empty</span>{/if}
+												</td>
+											</tr>
+										{/each}
+									</tbody>
+								</table>
+							</div>
+							<div class="mt-3">
+								<p class="font-semibold">Required moves ({proposal.moves.length})</p>
+								{#if proposal.moves.length === 0}
+									<p class="text-sm opacity-70">No changes needed.</p>
+								{:else}
+									<ul class="list-disc pl-5 text-sm">
+										{#each proposal.moves as move (`${move.classId}-${move.from}-${move.to}`)}
+											<li>
+												{#await getClass(move.classId) then resolvedClass}
+													{titlecase(resolvedClass.name)}
+												{:catch}{move.classId}{/await}:
+												{move.from.toUpperCase()} → {move.to.toUpperCase()}
+											</li>
+										{/each}
+									</ul>
+								{/if}
+							</div>
+						</article>
+					{/each}
+				</div>
+				<div class="alert alert-info mt-5">
+					<span>This proposal is a preview only. No stored schedule has been modified.</span>
+				</div>
+			</section>
+		{/if}
+	{/if}
+</section>

--- a/tests/engineer.spec.ts
+++ b/tests/engineer.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '@playwright/test';
+import { engineerSchedules, type EngineerInput } from '../src/lib/engineer';
+import type { VirtualSchedule } from '../src/lib/InfoInput.d';
+
+function schedule(...classes: string[]): VirtualSchedule {
+	const values = [...classes, ...Array(8).fill('')].slice(0, 8);
+	return {
+		'1a': values[0],
+		'1b': values[1],
+		'2a': values[2],
+		'2b': values[3],
+		'3a': values[4],
+		'3b': values[5],
+		'4a': values[6],
+		'4b': values[7]
+	};
+}
+
+test('maximizes anchor matches before minimizing movements and is deterministic', () => {
+	const inputs: EngineerInput[] = [
+		{ student: 'Avery', schedule: schedule('math', 'art') },
+		{ student: 'Blake', schedule: schedule('art', 'math') }
+	];
+
+	const first = engineerSchedules(inputs);
+	const second = engineerSchedules(inputs);
+
+	expect(first).toEqual(second);
+	expect(first.status).toBe('success');
+	if (first.status !== 'success') return;
+	expect(first.sharedPlacements).toBe(2);
+	expect(first.movementCost).toBe(2);
+	expect(first.schedules.flatMap(({ moves }) => moves)).toHaveLength(2);
+	for (const period of ['1a', '1b'] as const) {
+		expect(first.schedules[0].proposed[period]).toBe(first.schedules[1].proposed[period]);
+	}
+});
+
+test('respects locked classes and locked periods', () => {
+	const result = engineerSchedules([
+		{
+			student: 'Anchor',
+			schedule: schedule('math', 'art', 'science'),
+			locks: { periods: ['1a'] }
+		},
+		{
+			student: 'Friend',
+			schedule: schedule('art', 'math', 'science'),
+			locks: { classes: ['math'] }
+		}
+	]);
+
+	expect(result.status).toBe('success');
+	if (result.status !== 'success') return;
+	const [anchor, friend] = result.schedules;
+	expect(anchor.proposed['1a']).toBe('math');
+	expect(friend.proposed['1b']).toBe('math');
+	expect(anchor.moves).not.toContainEqual(expect.objectContaining({ classId: 'math' }));
+	expect(friend.moves).not.toContainEqual(expect.objectContaining({ classId: 'math' }));
+	expect(result.sharedPlacements).toBe(2);
+});
+
+test('handles incomplete schedules without treating blank periods as shared classes', () => {
+	const result = engineerSchedules([
+		{ student: 'Anchor', schedule: schedule('math') },
+		{ student: 'Friend', schedule: schedule('math') }
+	]);
+
+	expect(result.status).toBe('success');
+	if (result.status !== 'success') return;
+	expect(result.sharedPlacements).toBe(1);
+	expect(result.movementCost).toBe(0);
+	expect(result.schedules[0].proposed).toEqual(schedule('math'));
+});
+
+test('reports empty selection and invalid duplicate classes', () => {
+	expect(engineerSchedules([])).toEqual({ status: 'empty' });
+	const result = engineerSchedules([{ student: 'Avery', schedule: schedule('math', 'math') }]);
+	expect(result.status).toBe('no-solution');
+	if (result.status === 'no-solution') expect(result.reason).toContain('same class more than once');
+});
+
+test('does not mutate stored schedule inputs', () => {
+	const original = schedule('math', 'art');
+	const friend = schedule('art', 'math');
+	const snapshot = structuredClone([original, friend]);
+
+	engineerSchedules([
+		{ student: 'Anchor', schedule: original },
+		{ student: 'Friend', schedule: friend }
+	]);
+
+	expect([original, friend]).toEqual(snapshot);
+});


### PR DESCRIPTION
## Summary

- replace the unfinished schedule heuristic with a deterministic, constraint-aware optimizer
- add student selection/removal, class and period locks, proposal tables, movement summaries, and clear empty/error/incomplete states
- enable the Schedule Engineer tab while keeping every proposal preview-only
- add focused optimizer tests for objectives, tie-breaking, constraints, edge cases, and immutability

## Optimization contract

The first selected student is the anchor. The optimizer maximizes anchor-to-friend shared class/period placements, then minimizes the total number of moved classes, then applies a lexicographic tie-break so repeated inputs always produce the same proposal.

## Validation

- `pnpm run check` (0 errors; 3 pre-existing warnings outside this change)
- `pnpm exec eslint` on all changed source and test files
- `pnpm exec prettier --plugin=prettier-plugin-svelte --check` on all changed files
- `pnpm run build`
- full Playwright suite: 6 passed

Closes #47
