### PR TITLE
Add screenshot schedule import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
             test -s .env
       - name: Install again, just in case
         run: npx playwright install
+      - run: pnpm run test:unit
       - run: pnpm test
   check-types:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
         run: |
           supabase db start
           supabase db reset
+      - name: Cache Postgres Meta image
+        run: |
+          docker pull ghcr.io/supabase/postgres-meta:v0.96.1
+          docker tag ghcr.io/supabase/postgres-meta:v0.96.1 public.ecr.aws/supabase/postgres-meta:v0.96.1
       - name: Verify generated types match Postgres schema
         run: |
           supabase gen types typescript --local > src/lib/supabase.d.ts

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"package": "svelte-kit package",
 		"preview": "vite preview",
 		"test": "playwright test",
+		"test:unit": "node --test tests/*.unit.ts",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
@@ -28,6 +29,7 @@
 		"@sveltejs/vite-plugin-svelte": "^7.2.0",
 		"@tailwindcss/vite": "^4.3.2",
 		"@types/lodash-es": "^4.17.12",
+		"@types/node": "^24.13.3",
 		"daisyui": "^5.6.18",
 		"dotenv": "^17.4.2",
 		"eslint": "^10.7.0",
@@ -57,6 +59,7 @@
 		"clsx": "^2.1.1",
 		"mode-watcher": "^1.1.0",
 		"tailwind-merge": "^3.6.0",
-		"tailwind-variants": "^3.2.2"
+		"tailwind-variants": "^3.2.2",
+		"tesseract.js": "^7.0.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 2.110.2
       bits-ui:
         specifier: ^2.18.1
-        version: 2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))
+        version: 2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -42,6 +42,9 @@ importers:
       tailwind-variants:
         specifier: ^3.2.2
         version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
+      tesseract.js:
+        specifier: ^7.0.0
+        version: 7.0.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -51,19 +54,22 @@ importers:
         version: 1.61.1
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
-        version: 7.0.1(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(jiti@2.7.0)))
+        version: 7.0.1(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))
       '@sveltejs/kit':
         specifier: ^2.69.2
-        version: 2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(jiti@2.7.0))
+        version: 2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.2.0
-        version: 7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0))
+        version: 7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))
       '@tailwindcss/vite':
         specifier: ^4.3.2
-        version: 4.3.2(vite@8.1.4(jiti@2.7.0))
+        version: 4.3.2(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
       daisyui:
         specifier: ^5.6.18
         version: 5.6.18
@@ -114,7 +120,7 @@ importers:
         version: 8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)
       vite:
         specifier: ^8.1.4
-        version: 8.1.4(jiti@2.7.0)
+        version: 8.1.4(@types/node@24.13.3)(jiti@2.7.0)
 
 packages:
 
@@ -536,6 +542,9 @@ packages:
   '@types/lodash@4.17.7':
     resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
 
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -634,6 +643,9 @@ packages:
     peerDependencies:
       '@internationalized/date': ^3.8.1
       svelte: ^5.33.0
+
+  bmp-js@0.1.0:
+    resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
 
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
@@ -862,6 +874,9 @@ packages:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
 
+  idb-keyval@6.3.0:
+    resolution: {integrity: sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==}
+
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
@@ -887,6 +902,9 @@ packages:
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1047,9 +1065,22 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
+
+  opencollective-postinstall@2.0.3:
+    resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
+    hasBin: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1146,6 +1177,9 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
@@ -1263,6 +1297,12 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tesseract.js-core@7.0.0:
+    resolution: {integrity: sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==}
+
+  tesseract.js@7.0.0:
+    resolution: {integrity: sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -1270,6 +1310,9 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -1295,6 +1338,9 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1353,6 +1399,15 @@ packages:
       vite:
         optional: true
 
+  wasm-feature-detect@1.8.0:
+    resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1372,6 +1427,9 @@ packages:
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
+  zlibjs@0.3.1:
+    resolution: {integrity: sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==}
 
 snapshots:
 
@@ -1597,15 +1655,15 @@ snapshots:
     dependencies:
       acorn: 8.17.0
 
-  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(jiti@2.7.0)))':
+  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))':
     dependencies:
-      '@sveltejs/kit': 2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(jiti@2.7.0))
+      '@sveltejs/kit': 2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))
 
-  '@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(jiti@2.7.0))':
+  '@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.11(acorn@8.17.0)
-      '@sveltejs/vite-plugin-svelte': 7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))
       '@types/cookie': 0.6.0
       acorn: 8.17.0
       cookie: 0.6.0
@@ -1617,20 +1675,20 @@ snapshots:
       set-cookie-parser: 3.1.2
       sirv: 3.0.2
       svelte: 5.56.4(@typescript-eslint/types@8.63.0)
-      vite: 8.1.4(jiti@2.7.0)
+      vite: 8.1.4(@types/node@24.13.3)(jiti@2.7.0)
     optionalDependencies:
       typescript: 6.0.3
 
   '@sveltejs/load-config@0.2.0': {}
 
-  '@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0))':
+  '@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.3
       svelte: 5.56.4(@typescript-eslint/types@8.63.0)
-      vite: 8.1.4(jiti@2.7.0)
-      vitefu: 1.1.3(vite@8.1.4(jiti@2.7.0))
+      vite: 8.1.4(@types/node@24.13.3)(jiti@2.7.0)
+      vitefu: 1.1.3(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))
 
   '@swc/helpers@0.5.12':
     dependencies:
@@ -1697,12 +1755,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
 
-  '@tailwindcss/vite@4.3.2(vite@8.1.4(jiti@2.7.0))':
+  '@tailwindcss/vite@4.3.2(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))':
     dependencies:
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
       tailwindcss: 4.3.2
-      vite: 8.1.4(jiti@2.7.0)
+      vite: 8.1.4(@types/node@24.13.3)(jiti@2.7.0)
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -1724,6 +1782,10 @@ snapshots:
       '@types/lodash': 4.17.7
 
   '@types/lodash@4.17.7': {}
+
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
 
   '@types/trusted-types@2.0.7': {}
 
@@ -1839,18 +1901,20 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  bits-ui@2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0)):
+  bits-ui@2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0)):
     dependencies:
       '@floating-ui/core': 1.8.0
       '@floating-ui/dom': 1.8.0
       '@internationalized/date': 3.12.2
       esm-env: 1.2.2
-      runed: 0.35.1(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))
+      runed: 0.35.1(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))
       svelte: 5.56.4(@typescript-eslint/types@8.63.0)
-      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))
+      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))
       tabbable: 6.2.0
     transitivePeerDependencies:
       - '@sveltejs/kit'
+
+  bmp-js@0.1.0: {}
 
   brace-expansion@5.0.7:
     dependencies:
@@ -2058,6 +2122,8 @@ snapshots:
 
   iceberg-js@0.8.1: {}
 
+  idb-keyval@6.3.0: {}
+
   ignore@5.3.1: {}
 
   ignore@7.0.6: {}
@@ -2075,6 +2141,8 @@ snapshots:
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  is-url@1.2.4: {}
 
   isexe@2.0.0: {}
 
@@ -2190,7 +2258,13 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   obug@2.1.3: {}
+
+  opencollective-postinstall@2.0.3: {}
 
   optionator@0.9.4:
     dependencies:
@@ -2266,6 +2340,8 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  regenerator-runtime@0.13.11: {}
+
   rolldown@1.1.5:
     dependencies:
       '@oxc-project/types': 0.139.0
@@ -2297,14 +2373,14 @@ snapshots:
       esm-env: 1.2.2
       svelte: 5.56.4(@typescript-eslint/types@8.63.0)
 
-  runed@0.35.1(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0)):
+  runed@0.35.1(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0)):
     dependencies:
       dequal: 2.0.3
       esm-env: 1.2.2
       lz-string: 1.5.0
       svelte: 5.56.4(@typescript-eslint/types@8.63.0)
     optionalDependencies:
-      '@sveltejs/kit': 2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(jiti@2.7.0))
+      '@sveltejs/kit': 2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))
 
   sade@1.8.1:
     dependencies:
@@ -2359,10 +2435,10 @@ snapshots:
     optionalDependencies:
       svelte: 5.56.4(@typescript-eslint/types@8.63.0)
 
-  svelte-toolbelt@0.10.6(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0)):
+  svelte-toolbelt@0.10.6(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0)):
     dependencies:
       clsx: 2.1.1
-      runed: 0.35.1(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))
+      runed: 0.35.1(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))
       style-to-object: 1.0.14
       svelte: 5.56.4(@typescript-eslint/types@8.63.0)
     transitivePeerDependencies:
@@ -2410,12 +2486,30 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tesseract.js-core@7.0.0: {}
+
+  tesseract.js@7.0.0:
+    dependencies:
+      bmp-js: 0.1.0
+      idb-keyval: 6.3.0
+      is-url: 1.2.4
+      node-fetch: 2.7.0
+      opencollective-postinstall: 2.0.3
+      regenerator-runtime: 0.13.11
+      tesseract.js-core: 7.0.0
+      wasm-feature-detect: 1.8.0
+      zlibjs: 0.3.1
+    transitivePeerDependencies:
+      - encoding
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
   totalist@3.0.1: {}
+
+  tr46@0.0.3: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -2440,13 +2534,15 @@ snapshots:
 
   typescript@6.0.3: {}
 
+  undici-types@7.18.2: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
 
-  vite@8.1.4(jiti@2.7.0):
+  vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -2454,12 +2550,22 @@ snapshots:
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 24.13.3
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitefu@1.1.3(vite@8.1.4(jiti@2.7.0)):
+  vitefu@1.1.3(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0)):
     optionalDependencies:
-      vite: 8.1.4(jiti@2.7.0)
+      vite: 8.1.4(@types/node@24.13.3)(jiti@2.7.0)
+
+  wasm-feature-detect@1.8.0: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:
@@ -2472,3 +2578,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zimmerframe@1.1.4: {}
+
+  zlibjs@0.3.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,8 @@ allowBuilds:
   '@sveltejs/kit': true
   esbuild: true
   svelte-preprocess: true
+  # Only runs an optional OpenCollective message; OCR works without it.
+  tesseract.js: false
 onlyBuiltDependencies:
   - '@sveltejs/kit'
   - esbuild

--- a/src/lib/InfoInput.svelte
+++ b/src/lib/InfoInput.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ClassPicker from './ClassPicker.svelte';
+	import ScheduleImporter from './ScheduleImporter.svelte';
 	import type { UnfinishedSchedule, VirtualSchedule } from './InfoInput.d';
 	import type { Classes } from './InfoInput';
 
@@ -14,6 +15,7 @@
 	} = $props();
 
 	let name = $state('');
+	let confirmed = $state(false);
 	let periods: UnfinishedSchedule = $state({
 		'1a': undefined,
 		'2a': undefined,
@@ -36,7 +38,13 @@
 	function submit() {
 		onsubmit({ name: name.trim(), schedule: periods as VirtualSchedule });
 	}
+	function applyImportedSchedule(schedule: UnfinishedSchedule) {
+		periods = { ...periods, ...schedule };
+		confirmed = false;
+	}
 </script>
+
+<ScheduleImporter {classes} {addClass} onapply={applyImportedSchedule} />
 
 <div class="form-control">
 	<label class="label justify-center">
@@ -80,5 +88,16 @@
 </div>
 
 <div class="form-control mt-6">
-	<button class="btn btn-primary" disabled={!isValid} onclick={submit}>Done</button>
+	<label class="label justify-start gap-3 cursor-pointer">
+		<input
+			class="checkbox checkbox-primary"
+			type="checkbox"
+			bind:checked={confirmed}
+			disabled={!isValid}
+		/>
+		<span>I reviewed this schedule and confirm it is ready to submit.</span>
+	</label>
+	<button class="btn btn-primary" disabled={!isValid || !confirmed} onclick={submit}
+		>Submit schedule</button
+	>
 </div>

--- a/src/lib/ScheduleImporter.svelte
+++ b/src/lib/ScheduleImporter.svelte
@@ -1,0 +1,289 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { Classes, UnfinishedSchedule } from './InfoInput';
+	import {
+		extractScheduleCandidates,
+		matchCandidate,
+		toUnfinishedSchedule,
+		validateScheduleImage,
+		type ClassMatch,
+		type ScheduleCandidate
+	} from './scheduleImport';
+	import { titlecase } from './utils';
+
+	type PreviewRow = ScheduleCandidate & ClassMatch & { selectedClassId: string };
+	const EXAMPLE_TEXT = '1A | AP Biology | Jane Smith\n2A | English 10 | Alex Lee';
+
+	let {
+		classes,
+		addClass,
+		onapply
+	}: {
+		classes: Classes;
+		addClass: (info: { className: string; firstName: string; lastName: string }) => Promise<string>;
+		onapply: (schedule: UnfinishedSchedule) => void;
+	} = $props();
+
+	let dialog: HTMLDialogElement;
+	let sourceText = $state('');
+	let rows: PreviewRow[] = $state([]);
+	let error = $state('');
+	let processing = $state(false);
+	let progress = $state(0);
+	let confirmCreates = $state(false);
+	let applying = $state(false);
+	let hasUnresolved = $derived(rows.some((row) => !row.selectedClassId));
+	let needsCreates = $derived(rows.some((row) => !row.selectedClassId && row.className));
+
+	function preview(candidates: ScheduleCandidate[]) {
+		rows = candidates.map((candidate) => {
+			const match = matchCandidate(candidate, classes);
+			return {
+				...candidate,
+				...match,
+				selectedClassId: match.status === 'high' ? (match.classId ?? '') : ''
+			};
+		});
+		error = rows.length
+			? ''
+			: 'No schedule rows found. Include periods like 1A, 2A, or 1B in the text.';
+		confirmCreates = false;
+	}
+
+	function parseText() {
+		preview(extractScheduleCandidates(sourceText));
+	}
+
+	async function readImage(file: File) {
+		error = validateScheduleImage(file);
+		if (error) return;
+		processing = true;
+		progress = 0;
+		let worker: Awaited<ReturnType<(typeof import('tesseract.js'))['createWorker']>> | undefined;
+		try {
+			const { createWorker } = await import('tesseract.js');
+			worker = await createWorker('eng', 1, {
+				logger: (message) => {
+					if (typeof message.progress === 'number') progress = Math.round(message.progress * 100);
+				}
+			});
+			const result = await worker.recognize(file);
+			sourceText = result.data.text;
+			preview(extractScheduleCandidates(sourceText));
+		} catch (reason) {
+			console.error(reason);
+			error =
+				'We could not read that image. Try a clearer screenshot or paste the schedule as text.';
+		} finally {
+			await worker?.terminate();
+			processing = false;
+			progress = 0;
+		}
+	}
+
+	function updateRow(index: number, patch: Partial<PreviewRow>) {
+		const edited = { ...rows[index], ...patch };
+		if ('className' in patch || 'teacherFirst' in patch || 'teacherLast' in patch) {
+			const match = matchCandidate(edited, classes);
+			Object.assign(edited, match, {
+				selectedClassId: match.status === 'high' ? (match.classId ?? '') : ''
+			});
+		}
+		rows[index] = edited;
+		rows = [...rows];
+	}
+
+	async function applyPreview() {
+		applying = true;
+		error = '';
+		try {
+			const resolved: Array<{ period: PreviewRow['period']; classId: string }> = [];
+			for (const row of rows) {
+				let classId = row.selectedClassId;
+				if (!classId) {
+					if (!confirmCreates) throw new Error('Confirm new class creation before applying.');
+					if (!row.className || !row.teacherFirst || !row.teacherLast) {
+						throw new Error(
+							`${row.period.toUpperCase()} needs a class and the teacher's first and last name.`
+						);
+					}
+					classId = await addClass({
+						className: row.className,
+						firstName: row.teacherFirst,
+						lastName: row.teacherLast
+					});
+				}
+				resolved.push({ period: row.period, classId });
+			}
+			onapply(toUnfinishedSchedule(resolved));
+			dialog.close();
+		} catch (reason) {
+			error = reason instanceof Error ? reason.message : 'Could not apply the imported schedule.';
+		} finally {
+			applying = false;
+		}
+	}
+
+	onMount(() => {
+		const handlePaste = (event: ClipboardEvent) => {
+			if (!dialog.open) return;
+			const image = Array.from(event.clipboardData?.files ?? []).find((file) =>
+				file.type.startsWith('image/')
+			);
+			if (image) {
+				event.preventDefault();
+				void readImage(image);
+			}
+		};
+		window.addEventListener('paste', handlePaste);
+		return () => window.removeEventListener('paste', handlePaste);
+	});
+</script>
+
+<button
+	class="btn btn-outline btn-secondary w-full mb-4"
+	type="button"
+	onclick={() => dialog.showModal()}
+>
+	Import screenshot or text
+</button>
+
+<dialog bind:this={dialog} class="modal">
+	<div class="modal-box max-w-5xl max-h-[90vh]">
+		<form method="dialog">
+			<button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" aria-label="Close"
+				>✕</button
+			>
+		</form>
+		<h3 class="text-3xl font-bold">Import your schedule</h3>
+		<p class="mt-2 text-sm">
+			Your image is read locally in this browser and is never uploaded to Wuzursched or an OCR
+			service. It is discarded as soon as processing finishes. OCR may download its language model.
+		</p>
+
+		<label class="mt-4 block">
+			<span class="label-text font-bold">Screenshot (PNG, JPEG, or WebP; 10 MB max)</span>
+			<input
+				class="file-input file-input-bordered w-full"
+				type="file"
+				accept="image/png,image/jpeg,image/webp"
+				disabled={processing}
+				onchange={(event) => {
+					const file = event.currentTarget.files?.[0];
+					if (file) void readImage(file);
+					event.currentTarget.value = '';
+				}}
+			/>
+		</label>
+		<p class="text-xs opacity-70 mt-1">You can also paste an image while this window is open.</p>
+
+		{#if processing}
+			<div class="my-4" role="status">
+				<progress class="progress progress-primary w-full" value={progress} max="100"></progress>
+				<p>Reading image… {progress}%</p>
+			</div>
+		{/if}
+
+		<label class="mt-4 block">
+			<span class="label-text font-bold">Or paste schedule text</span>
+			<textarea
+				class="textarea textarea-bordered h-28 w-full"
+				bind:value={sourceText}
+				placeholder={EXAMPLE_TEXT}></textarea>
+		</label>
+		<button
+			class="btn btn-secondary mt-2"
+			type="button"
+			disabled={!sourceText.trim() || processing}
+			onclick={parseText}>Preview text</button
+		>
+
+		{#if error}<div class="alert alert-error mt-4" role="alert">{error}</div>{/if}
+
+		{#if rows.length}
+			<div class="overflow-x-auto mt-5">
+				<table class="table table-sm">
+					<thead
+						><tr
+							><th>Period</th><th>Class</th><th>Teacher first</th><th>Teacher last</th><th
+								>Room class match</th
+							></tr
+						></thead
+					>
+					<tbody>
+						{#each rows as row, index (row.period)}
+							<tr>
+								<th>{row.period.toUpperCase()}</th>
+								<td
+									><input
+										class="input input-bordered input-sm min-w-36"
+										value={row.className}
+										oninput={(event) => updateRow(index, { className: event.currentTarget.value })}
+									/></td
+								>
+								<td
+									><input
+										class="input input-bordered input-sm w-28"
+										value={row.teacherFirst}
+										oninput={(event) =>
+											updateRow(index, { teacherFirst: event.currentTarget.value })}
+									/></td
+								>
+								<td
+									><input
+										class="input input-bordered input-sm w-28"
+										value={row.teacherLast}
+										oninput={(event) =>
+											updateRow(index, { teacherLast: event.currentTarget.value })}
+									/></td
+								>
+								<td>
+									<select
+										class="select select-bordered select-sm min-w-52"
+										value={row.selectedClassId}
+										onchange={(event) =>
+											updateRow(index, { selectedClassId: event.currentTarget.value })}
+									>
+										<option value="">Create as new class</option>
+										{#each classes as klass (klass.id)}<option value={klass.id}
+												>{titlecase(klass.name)} — {titlecase(klass.teacher_first)}
+												{titlecase(klass.teacher_last)}{klass.id === row.classId &&
+												row.status !== 'none'
+													? ` (suggested ${Math.round(row.confidence * 100)}%)`
+													: ''}</option
+											>{/each}
+									</select>
+									{#if row.status === 'high'}<span class="badge badge-success ml-2"
+											>High confidence</span
+										>{:else if row.status === 'uncertain'}<span class="badge badge-warning ml-2"
+											>Uncertain {Math.round(row.confidence * 100)}%</span
+										>{:else}<span class="badge badge-ghost ml-2">No match</span>{/if}
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+			{#if needsCreates || hasUnresolved}
+				<label class="label justify-start gap-3 mt-4 cursor-pointer"
+					><input
+						class="checkbox checkbox-warning"
+						type="checkbox"
+						bind:checked={confirmCreates}
+					/><span
+						>I reviewed the unmatched rows and explicitly approve creating these new room classes.</span
+					></label
+				>
+			{/if}
+			<div class="modal-action">
+				<button
+					class="btn btn-primary"
+					type="button"
+					disabled={applying || (hasUnresolved && !confirmCreates)}
+					onclick={applyPreview}>{applying ? 'Applying…' : 'Apply to schedule form'}</button
+				>
+			</div>
+		{/if}
+	</div>
+	<form method="dialog" class="modal-backdrop"><button>Close</button></form>
+</dialog>

--- a/src/lib/scheduleImport.ts
+++ b/src/lib/scheduleImport.ts
@@ -1,0 +1,148 @@
+import type { Class, UnfinishedSchedule } from './InfoInput';
+
+export const IMPORT_PERIODS = ['1a', '2a', '3a', '4a', '1b', '2b', '3b', '4b'] as const;
+export type ImportPeriod = (typeof IMPORT_PERIODS)[number];
+
+export type ScheduleCandidate = {
+	period: ImportPeriod;
+	className: string;
+	teacherFirst: string;
+	teacherLast: string;
+};
+
+export type ClassMatch = {
+	classId: string | null;
+	confidence: number;
+	status: 'high' | 'uncertain' | 'none';
+};
+
+export const MAX_SCHEDULE_IMAGE_SIZE = 10 * 1024 * 1024;
+export const SCHEDULE_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp']);
+
+export function validateScheduleImage(file: Pick<File, 'type' | 'size'>) {
+	if (!SCHEDULE_IMAGE_TYPES.has(file.type)) return 'Choose a PNG, JPEG, or WebP image.';
+	if (file.size > MAX_SCHEDULE_IMAGE_SIZE) return 'The image must be 10 MB or smaller.';
+	return '';
+}
+
+const PERIOD_PATTERN = /(?:period\s*)?([1-4])\s*([ab])\b/i;
+
+function clean(value: string) {
+	return value
+		.replace(/^[\s|,:;\-–—]+|[\s|,:;\-–—]+$/g, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+function splitTeacher(value: string): Pick<ScheduleCandidate, 'teacherFirst' | 'teacherLast'> {
+	const teacher = clean(value.replace(/^(?:teacher|instructor|mr\.?|mrs\.?|ms\.?|dr\.?)\s*/i, ''));
+	if (!teacher) return { teacherFirst: '', teacherLast: '' };
+	if (teacher.includes(',')) {
+		const [last, ...first] = teacher.split(',');
+		return { teacherFirst: clean(first.join(' ')), teacherLast: clean(last) };
+	}
+	const parts = teacher.split(/\s+/);
+	if (parts.length === 1) return { teacherFirst: '', teacherLast: parts[0] };
+	return { teacherFirst: parts.slice(0, -1).join(' '), teacherLast: parts.at(-1)! };
+}
+
+function parseDetails(value: string) {
+	const normalized = clean(value.replace(/^[:|\-–—]+/, ''));
+	const parts = normalized
+		.split(/\s*(?:\||\t|\s[-–—]\s|\s{2,})\s*/)
+		.map(clean)
+		.filter(Boolean);
+	let className = parts[0] ?? '';
+	let teacher = parts.slice(1).join(' ');
+	if (!teacher) {
+		const teacherMatch = className.match(/^(.*?)\s+(?:teacher|instructor)\s*:?\s*(.+)$/i);
+		if (teacherMatch) {
+			className = clean(teacherMatch[1]);
+			teacher = clean(teacherMatch[2]);
+		}
+	}
+	return { className, ...splitTeacher(teacher) };
+}
+
+/** Extracts schedule rows from OCR output or pasted text without retaining the source image. */
+export function extractScheduleCandidates(text: string): ScheduleCandidate[] {
+	const candidates = new Map<ImportPeriod, ScheduleCandidate>();
+	const lines = text
+		.replace(/\r/g, '')
+		.split('\n')
+		.map((line) => line.trim())
+		.filter(Boolean);
+
+	for (let index = 0; index < lines.length; index += 1) {
+		const match = lines[index].match(PERIOD_PATTERN);
+		if (!match) continue;
+		const period = `${match[1]}${match[2].toLowerCase()}` as ImportPeriod;
+		let details = clean(lines[index].slice((match.index ?? 0) + match[0].length));
+		if (!details && lines[index + 1] && !PERIOD_PATTERN.test(lines[index + 1])) {
+			details = lines[++index];
+		}
+		const parsed = parseDetails(details);
+		if (parsed.className) candidates.set(period, { period, ...parsed });
+	}
+
+	return IMPORT_PERIODS.flatMap((period) => {
+		const candidate = candidates.get(period);
+		return candidate ? [candidate] : [];
+	});
+}
+
+function comparable(value: string) {
+	return value
+		.toLowerCase()
+		.normalize('NFKD')
+		.replace(/[^a-z0-9]+/g, ' ')
+		.trim();
+}
+
+function levenshtein(left: string, right: string) {
+	const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+	for (let i = 1; i <= left.length; i += 1) {
+		let diagonal = previous[0];
+		previous[0] = i;
+		for (let j = 1; j <= right.length; j += 1) {
+			const above = previous[j];
+			previous[j] = Math.min(
+				previous[j] + 1,
+				previous[j - 1] + 1,
+				diagonal + (left[i - 1] === right[j - 1] ? 0 : 1)
+			);
+			diagonal = above;
+		}
+	}
+	return previous[right.length];
+}
+
+function similarity(left: string, right: string) {
+	const a = comparable(left);
+	const b = comparable(right);
+	if (!a || !b) return 0;
+	if (a === b) return 1;
+	return 1 - levenshtein(a, b) / Math.max(a.length, b.length);
+}
+
+export function matchCandidate(candidate: ScheduleCandidate, classes: Class[]): ClassMatch {
+	let best: { id: string; score: number } | null = null;
+	for (const klass of classes) {
+		const classScore = similarity(candidate.className, klass.name);
+		const candidateTeacher = `${candidate.teacherFirst} ${candidate.teacherLast}`.trim();
+		const classTeacher = `${klass.teacher_first} ${klass.teacher_last}`.trim();
+		const teacherScore = candidateTeacher ? similarity(candidateTeacher, classTeacher) : classScore;
+		const score = classScore * 0.72 + teacherScore * 0.28;
+		if (!best || score > best.score) best = { id: klass.id, score };
+	}
+	if (!best || best.score < 0.5)
+		return { classId: null, confidence: best?.score ?? 0, status: 'none' };
+	if (best.score < 0.82) return { classId: best.id, confidence: best.score, status: 'uncertain' };
+	return { classId: best.id, confidence: best.score, status: 'high' };
+}
+
+export function toUnfinishedSchedule(rows: Array<{ period: ImportPeriod; classId: string }>) {
+	return Object.fromEntries(
+		rows.map(({ period, classId }) => [period, classId])
+	) as UnfinishedSchedule;
+}

--- a/tests/fixtures/schedule-import/ambiguous.txt
+++ b/tests/fixtures/schedule-import/ambiguous.txt
@@ -1,0 +1,5 @@
+PERIOD 1A  AP Bio  -  J. Smith
+Period 2A: English 10 Teacher: Lee
+3B | Computer Scienee | Jordan Kim
+4B
+Physical Education | Casey Jones

--- a/tests/fixtures/schedule-import/standard.txt
+++ b/tests/fixtures/schedule-import/standard.txt
@@ -1,0 +1,9 @@
+Student Schedule
+1A | AP Biology | Jane Smith
+2A | English 10 | Alex Lee
+3A | Algebra II | Priya Patel
+4A | World History | Morgan Chen
+1B | Spanish III | Elena Garcia
+2B | Studio Art | Taylor Brown
+3B | Computer Science | Jordan Kim
+4B | PE | Casey Jones

--- a/tests/schedule-import.unit.ts
+++ b/tests/schedule-import.unit.ts
@@ -1,0 +1,92 @@
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	extractScheduleCandidates,
+	matchCandidate,
+	toUnfinishedSchedule,
+	validateScheduleImage
+} from '../src/lib/scheduleImport.ts';
+
+const fixtures = new URL('./fixtures/schedule-import/', import.meta.url);
+
+describe('schedule import', () => {
+	it('extracts all periods, classes, and teachers from a standard layout', async () => {
+		const rows = extractScheduleCandidates(
+			await readFile(new URL('standard.txt', fixtures), 'utf8')
+		);
+		assert.equal(rows.length, 8);
+		assert.deepEqual(rows[0], {
+			period: '1a',
+			className: 'AP Biology',
+			teacherFirst: 'Jane',
+			teacherLast: 'Smith'
+		});
+		assert.deepEqual(rows[7], {
+			period: '4b',
+			className: 'PE',
+			teacherFirst: 'Casey',
+			teacherLast: 'Jones'
+		});
+	});
+
+	it('handles OCR-like and multiline ambiguous text', async () => {
+		const rows = extractScheduleCandidates(
+			await readFile(new URL('ambiguous.txt', fixtures), 'utf8')
+		);
+		assert.deepEqual(
+			rows.map((row) => row.period),
+			['1a', '2a', '3b', '4b']
+		);
+		assert.equal(rows.at(-1)?.className, 'Physical Education');
+	});
+
+	it('auto-selects only high-confidence room matches', () => {
+		const classes = [
+			{
+				id: 'biology',
+				name: 'ap biology',
+				teacher_first: 'jane',
+				teacher_last: 'smith',
+				room: 'room'
+			}
+		];
+		assert.equal(
+			matchCandidate(
+				{ period: '1a', className: 'AP Biology', teacherFirst: 'Jane', teacherLast: 'Smith' },
+				classes
+			).status,
+			'high'
+		);
+		assert.equal(
+			matchCandidate(
+				{ period: '1a', className: 'AP Bio', teacherFirst: 'J', teacherLast: 'Smith' },
+				classes
+			).status,
+			'uncertain'
+		);
+		assert.equal(
+			matchCandidate(
+				{ period: '1a', className: 'Ceramics', teacherFirst: 'A', teacherLast: 'Lee' },
+				classes
+			).status,
+			'none'
+		);
+	});
+
+	it('maps confirmed rows into the normal schedule form shape', () => {
+		assert.deepEqual(
+			toUnfinishedSchedule([
+				{ period: '1a', classId: 'class-1' },
+				{ period: '2b', classId: 'class-2' }
+			]),
+			{ '1a': 'class-1', '2b': 'class-2' }
+		);
+	});
+
+	it('rejects unsupported and oversized image uploads', () => {
+		assert.match(validateScheduleImage({ type: 'application/pdf', size: 1 }), /PNG/);
+		assert.match(validateScheduleImage({ type: 'image/png', size: 10 * 1024 * 1024 + 1 }), /10 MB/);
+		assert.equal(validateScheduleImage({ type: 'image/jpeg', size: 10 * 1024 * 1024 }), '');
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
 		"allowJs": true,
+		"allowImportingTsExtensions": true,
 		"checkJs": true,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

- add browser-local OCR for PNG, JPEG, and WebP schedule screenshots, including pasted images
- parse pasted text into period, class, and teacher candidates
- confidence-match candidates against existing room classes and clearly flag uncertain or missing matches
- provide an editable preview before applying values to the existing schedule form
- require explicit confirmation before creating unmatched classes and before submitting the final schedule
- disclose image handling and discard image/worker references after processing
- add representative and ambiguous layout fixtures plus parser, matcher, mapping, and validation tests

## Validation

- `pnpm run test:unit`
- `pnpm test`
- `pnpm run build`
- targeted Prettier and ESLint checks for all changed source and test files

Repository-wide `pnpm run check` still reports pre-existing errors in `src/lib/engineer.ts` and environment-generated Supabase imports. Repository-wide `pnpm run lint` still reports the pre-existing formatting issue in `src/lib/supabase.d.ts`.

Closes #58
