### PR TITLE
Add secure room administration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+src/lib/supabase.d.ts

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,11 +2,13 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 import dotenv from 'dotenv';
 
 dotenv.config();
+const port = Number(process.env.PLAYWRIGHT_PORT ?? 4173);
 const config: PlaywrightTestConfig = {
 	webServer: {
-		command: 'pnpm run build && pnpm run preview',
-		port: 4173
-	}
+		command: `pnpm run build && pnpm run preview --port ${port}`,
+		port
+	},
+	use: { baseURL: `http://localhost:${port}` }
 };
 
 export default config;

--- a/src/lib/ClassPicker.svelte
+++ b/src/lib/ClassPicker.svelte
@@ -8,11 +8,17 @@
 
 	let {
 		addClass,
+		canCreateClass = true,
+		classNameFormat = 'normalized',
+		teacherNameFormat = 'title',
 		classes,
 		selected = $bindable(),
 		period = ''
 	}: {
 		addClass: (info: { className: string; firstName: string; lastName: string }) => Promise<string>;
+		canCreateClass?: boolean;
+		classNameFormat?: string;
+		teacherNameFormat?: string;
 		classes: MenuItem[];
 		selected?: string | null | undefined;
 		period?: string;
@@ -40,6 +46,11 @@
 	let firstNameValid = $derived(/^\w+$/.test(firstName.trim()));
 	let lastNameValid = $derived(/^\w+$/.test(lastName.trim().replaceAll(/\s+/g, '')));
 	let isValidClassInfo = $derived(classNameValid && firstNameValid && lastNameValid);
+	const titleWords = (value: string) => value.replace(/\b\w/g, (letter) => letter.toUpperCase());
+	const displayClass = (value: string) =>
+		classNameFormat === 'preserve' ? value : titleWords(value);
+	const displayTeacher = (value: string) =>
+		teacherNameFormat === 'preserve' ? value : titleWords(value);
 </script>
 
 <div class="tooltip" data-tip={selectedClassName ? titlecase(selectedClassName) : undefined}>
@@ -55,70 +66,76 @@
 <dialog bind:this={dialog} class="modal">
 	<form method="dialog" class="modal-box">
 		<button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-		<div class="form-control">
-			<span>Search/Create a class for {period}</span>
-			<label class="join">
-				<input
-					type="text"
-					placeholder="Class name"
-					class="input input-bordered w-32 join-item"
-					bind:value={className}
-				/>
-				<input
-					type="text"
-					placeholder="John"
-					class="input input-bordered w-20 join-item"
-					bind:value={firstName}
-				/>
-				<input
-					type="text"
-					placeholder="Doe"
-					class="input input-bordered w-20 join-item"
-					bind:value={lastName}
-				/>
-				<button
-					class="btn btn-primary join-item"
-					onclick={async (event) => {
-						if (!isValidClassInfo) {
-							console.log(className, firstName, lastName);
-							if (!classNameValid) {
-								addToast('Class name must not be empty', 'error');
+		{#if canCreateClass}
+			<div class="form-control">
+				<span>Search/Create a class for {period}</span>
+				<label class="join">
+					<input
+						type="text"
+						placeholder="Class name"
+						class="input input-bordered w-32 join-item"
+						bind:value={className}
+					/>
+					<input
+						type="text"
+						placeholder="John"
+						class="input input-bordered w-20 join-item"
+						bind:value={firstName}
+					/>
+					<input
+						type="text"
+						placeholder="Doe"
+						class="input input-bordered w-20 join-item"
+						bind:value={lastName}
+					/>
+					<button
+						class="btn btn-primary join-item"
+						onclick={async (event) => {
+							if (!isValidClassInfo) {
+								console.log(className, firstName, lastName);
+								if (!classNameValid) {
+									addToast('Class name must not be empty', 'error');
+								}
+								if (!firstNameValid) {
+									addToast("The teacher's first name must be a single word", 'error');
+								}
+								if (!lastNameValid) {
+									addToast("The teacher's last name must not be empty", 'error');
+								}
+								event.preventDefault();
+								return;
 							}
-							if (!firstNameValid) {
-								addToast("The teacher's first name must be a single word", 'error');
-							}
-							if (!lastNameValid) {
-								addToast("The teacher's last name must not be empty", 'error');
-							}
-							event.preventDefault();
-							return;
-						}
-						selectedClassName = className;
-						selected = await addClass({
-							className,
-							firstName: firstName.trim(),
-							lastName: lastName.trim().replaceAll(/\s+/g, '')
-						});
-						// Reset the search
-						className = '';
-						firstName = '';
-						lastName = '';
-					}}
-					><svg
-						xmlns="http://www.w3.org/2000/svg"
-						class="h-5 w-5"
-						viewBox="0 0 20 20"
-						fill="currentColor"
-					>
-						<path
-							fill-rule="evenodd"
-							d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
-							clip-rule="evenodd"
-						/>
-					</svg></button
-				></label
-			>
-		</div>
+							selectedClassName = className;
+							selected = await addClass({
+								className,
+								firstName: firstName.trim(),
+								lastName: lastName.trim().replaceAll(/\s+/g, '')
+							});
+							// Reset the search
+							className = '';
+							firstName = '';
+							lastName = '';
+						}}
+						><svg
+							xmlns="http://www.w3.org/2000/svg"
+							class="h-5 w-5"
+							viewBox="0 0 20 20"
+							fill="currentColor"
+						>
+							<path
+								fill-rule="evenodd"
+								d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
+								clip-rule="evenodd"
+							/>
+						</svg></button
+					></label
+				>
+			</div>
+		{:else}
+			<p class="text-sm opacity-70">
+				Search the admin-maintained class list. Visitor class creation is disabled.
+			</p>
+		{/if}
 		<ul class="menu h-60 overflow-hidden overflow-y-scroll flex-nowrap">
 			<li class="menu-title">Classes</li>
 			{#each filtered as entry (entry.item.id)}
@@ -141,24 +158,24 @@
 						}}
 					>
 						<span class:active={isSelected}
-							>{titlecase(klass['name'])}
+							>{displayClass(klass['name'])}
 							<span class="text-sm text-gray-500" class:text-white={isSelected}
-								>{titlecase(klass.teacher_first)} {titlecase(klass.teacher_last)}</span
+								>{displayTeacher(klass.teacher_first)} {displayTeacher(klass.teacher_last)}</span
 							></span
 						>
 					</li>
 				{:else}
 					<li class="disabled">
 						<span
-							>{titlecase(klass['name'])}
+							>{displayClass(klass['name'])}
 							<span class="text-sm text-gray-500"
-								>{titlecase(klass.teacher_first)}
-								{titlecase(klass.teacher_last)} (already used in {klass.used})</span
+								>{displayTeacher(klass.teacher_first)}
+								{displayTeacher(klass.teacher_last)} (already used in {klass.used})</span
 							></span
 						>
 					</li>
 				{/if}
-			{:else}<p>No class found. Make one!</p>
+			{:else}<p>No class found.{canCreateClass ? ' Make one!' : ''}</p>
 			{/each}
 		</ul>
 	</form>

--- a/src/lib/InfoInput.svelte
+++ b/src/lib/InfoInput.svelte
@@ -6,10 +6,16 @@
 	let {
 		classes,
 		addClass,
+		canCreateClass = true,
+		classNameFormat = 'normalized',
+		teacherNameFormat = 'title',
 		onsubmit
 	}: {
 		classes: Classes;
 		addClass: (info: { className: string; firstName: string; lastName: string }) => Promise<string>;
+		canCreateClass?: boolean;
+		classNameFormat?: string;
+		teacherNameFormat?: string;
 		onsubmit: (detail: { name: string; schedule: VirtualSchedule }) => void;
 	} = $props();
 
@@ -54,6 +60,9 @@
 			<ClassPicker
 				bind:selected={periods[period]}
 				{addClass}
+				{canCreateClass}
+				{classNameFormat}
+				{teacherNameFormat}
 				period={period.toUpperCase()}
 				classes={classes.map((x) =>
 					Object.assign({}, x, {
@@ -68,6 +77,9 @@
 			<ClassPicker
 				bind:selected={periods[period]}
 				{addClass}
+				{canCreateClass}
+				{classNameFormat}
+				{teacherNameFormat}
 				period={period.toUpperCase()}
 				classes={classes.map((x) =>
 					Object.assign({}, x, {

--- a/src/lib/supabase.d.ts
+++ b/src/lib/supabase.d.ts
@@ -48,18 +48,65 @@ export type Database = {
       }
       rooms: {
         Row: {
+          allow_class_creation: boolean
+          announcement: string
+          class_name_format: string
           created_at: string | null
           id: string
+          teacher_name_format: string
         }
         Insert: {
+          allow_class_creation?: boolean
+          announcement?: string
+          class_name_format?: string
           created_at?: string | null
           id?: string
+          teacher_name_format?: string
         }
         Update: {
+          allow_class_creation?: boolean
+          announcement?: string
+          class_name_format?: string
           created_at?: string | null
           id?: string
+          teacher_name_format?: string
         }
         Relationships: []
+      }
+      room_audit_log: {
+        Row: {
+          action: string
+          affected_record: Json
+          affected_table: string
+          created_at: string
+          id: number
+          room: string
+        }
+        Insert: {
+          action: string
+          affected_record: Json
+          affected_table: string
+          created_at?: string
+          id?: never
+          room: string
+        }
+        Update: {
+          action?: string
+          affected_record?: Json
+          affected_table?: string
+          created_at?: string
+          id?: never
+          room?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "room_audit_log_room_fkey"
+            columns: ["room"]
+            isOneToOne: false
+            referencedRelation: "rooms"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       schedules: {
         Row: {
@@ -169,7 +216,41 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      admin_delete_schedule: {
+        Args: { p_room: string; p_student: string; p_token: string }
+        Returns: Database["public"]["Tables"]["schedules"]["Row"]
+      }
+      admin_rotate_token: {
+        Args: { p_new_token: string; p_room: string; p_token: string }
+        Returns: boolean
+      }
+      admin_seed_classes: {
+        Args: { p_classes: Json; p_room: string; p_token: string }
+        Returns: Database["public"]["Tables"]["classes"]["Row"][]
+      }
+      admin_update_room: {
+        Args: {
+          p_allow_class_creation: boolean
+          p_announcement: string
+          p_class_name_format: string
+          p_room: string
+          p_teacher_name_format: string
+          p_token: string
+        }
+        Returns: Database["public"]["Tables"]["rooms"]["Row"]
+      }
+      admin_update_schedule: {
+        Args: { p_room: string; p_schedule: Json; p_student: string; p_token: string }
+        Returns: Database["public"]["Tables"]["schedules"]["Row"]
+      }
+      create_room_with_admin: {
+        Args: { p_id: string; p_token: string }
+        Returns: string
+      }
+      verify_room_admin: {
+        Args: { p_room: string; p_token: string }
+        Returns: boolean
+      }
     }
     Enums: {
       [_ in never]: never

--- a/src/lib/supabase.d.ts
+++ b/src/lib/supabase.d.ts
@@ -66,33 +66,6 @@ export type Database = {
           },
         ]
       }
-      rooms: {
-        Row: {
-          allow_class_creation: boolean
-          announcement: string
-          class_name_format: string
-          created_at: string | null
-          id: string
-          teacher_name_format: string
-        }
-        Insert: {
-          allow_class_creation?: boolean
-          announcement?: string
-          class_name_format?: string
-          created_at?: string | null
-          id?: string
-          teacher_name_format?: string
-        }
-        Update: {
-          allow_class_creation?: boolean
-          announcement?: string
-          class_name_format?: string
-          created_at?: string | null
-          id?: string
-          teacher_name_format?: string
-        }
-        Relationships: []
-      }
       room_audit_log: {
         Row: {
           action: string
@@ -127,6 +100,33 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      rooms: {
+        Row: {
+          allow_class_creation: boolean
+          announcement: string
+          class_name_format: string
+          created_at: string | null
+          id: string
+          teacher_name_format: string
+        }
+        Insert: {
+          allow_class_creation?: boolean
+          announcement?: string
+          class_name_format?: string
+          created_at?: string | null
+          id?: string
+          teacher_name_format?: string
+        }
+        Update: {
+          allow_class_creation?: boolean
+          announcement?: string
+          class_name_format?: string
+          created_at?: string | null
+          id?: string
+          teacher_name_format?: string
+        }
+        Relationships: []
       }
       schedules: {
         Row: {
@@ -238,7 +238,24 @@ export type Database = {
     Functions: {
       admin_delete_schedule: {
         Args: { p_room: string; p_student: string; p_token: string }
-        Returns: Database["public"]["Tables"]["schedules"]["Row"]
+        Returns: {
+          "1a": string
+          "1b": string
+          "2a": string
+          "2b": string
+          "3a": string
+          "3b": string
+          "4a": string
+          "4b": string
+          room: string
+          student: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "schedules"
+          isOneToOne: true
+          isSetofReturn: false
+        }
       }
       admin_rotate_token: {
         Args: { p_new_token: string; p_room: string; p_token: string }
@@ -246,7 +263,19 @@ export type Database = {
       }
       admin_seed_classes: {
         Args: { p_classes: Json; p_room: string; p_token: string }
-        Returns: Database["public"]["Tables"]["classes"]["Row"][]
+        Returns: {
+          id: string
+          name: string
+          room: string
+          teacher_first: string
+          teacher_last: string
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "classes"
+          isOneToOne: false
+          isSetofReturn: true
+        }
       }
       admin_update_room: {
         Args: {
@@ -257,11 +286,46 @@ export type Database = {
           p_teacher_name_format: string
           p_token: string
         }
-        Returns: Database["public"]["Tables"]["rooms"]["Row"]
+        Returns: {
+          allow_class_creation: boolean
+          announcement: string
+          class_name_format: string
+          created_at: string | null
+          id: string
+          teacher_name_format: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "rooms"
+          isOneToOne: true
+          isSetofReturn: false
+        }
       }
       admin_update_schedule: {
-        Args: { p_room: string; p_schedule: Json; p_student: string; p_token: string }
-        Returns: Database["public"]["Tables"]["schedules"]["Row"]
+        Args: {
+          p_room: string
+          p_schedule: Json
+          p_student: string
+          p_token: string
+        }
+        Returns: {
+          "1a": string
+          "1b": string
+          "2a": string
+          "2b": string
+          "3a": string
+          "3b": string
+          "4a": string
+          "4b": string
+          room: string
+          student: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "schedules"
+          isOneToOne: true
+          isSetofReturn: false
+        }
       }
       create_room_with_admin: {
         Args: { p_id: string; p_token: string }

--- a/src/routes/create/+server.ts
+++ b/src/routes/create/+server.ts
@@ -1,13 +1,23 @@
 import { redirect } from '@sveltejs/kit';
 
+const adminCookie = (room: string) => `wuzursched_admin_${room}`;
+
 /** @type {import('./$types').RequestHandler} */
-export async function GET({ locals: { supabase } }) {
+export async function GET({ locals: { supabase }, cookies, url }) {
 	// TODO: Manage the rare case when crypto.randomUUID()
 	// is a pre-existing database
 	const id = crypto.randomUUID();
-	const error = (await supabase.from('rooms').insert([{ id }])).error;
+	const token = `${crypto.randomUUID().replaceAll('-', '')}${crypto.randomUUID().replaceAll('-', '')}`;
+	const error = (await supabase.rpc('create_room_with_admin', { p_id: id, p_token: token })).error;
 	if (error !== null) {
 		throw error;
 	}
+	cookies.set(adminCookie(id), token, {
+		path: `/room/${id}`,
+		httpOnly: true,
+		sameSite: 'strict',
+		secure: url.protocol === 'https:',
+		maxAge: 60 * 60 * 24 * 365
+	});
 	throw redirect(303, `/room/${id}`);
 }

--- a/src/routes/room/[room=uuid]/+page.server.ts
+++ b/src/routes/room/[room=uuid]/+page.server.ts
@@ -1,20 +1,207 @@
-import { error as returnError, type ServerLoad } from '@sveltejs/kit';
+import { error as returnError, fail, redirect, type Actions, type ServerLoad } from '@sveltejs/kit';
 
-export const load: ServerLoad = async ({ params, locals: { supabase } }) => {
+const adminCookie = (room: string) => `wuzursched_admin_${room}`;
+
+function newAdminToken() {
+	return `${crypto.randomUUID().replaceAll('-', '')}${crypto.randomUUID().replaceAll('-', '')}`;
+}
+
+function cookieOptions(room: string, secure: boolean) {
+	return {
+		path: `/room/${room}`,
+		httpOnly: true,
+		sameSite: 'strict' as const,
+		secure,
+		maxAge: 60 * 60 * 24 * 365
+	};
+}
+
+function parseCsv(source: string) {
+	const rows: string[][] = [];
+	let row: string[] = [];
+	let field = '';
+	let quoted = false;
+	for (let i = 0; i <= source.length; i += 1) {
+		const char = source[i] ?? '\n';
+		if (char === '"') {
+			if (quoted && source[i + 1] === '"') {
+				field += '"';
+				i += 1;
+			} else quoted = !quoted;
+		} else if (char === ',' && !quoted) {
+			row.push(field.trim());
+			field = '';
+		} else if ((char === '\n' || char === '\r') && !quoted) {
+			if (char === '\r' && source[i + 1] === '\n') i += 1;
+			row.push(field.trim());
+			if (row.some(Boolean)) rows.push(row);
+			row = [];
+			field = '';
+		} else field += char;
+	}
+	if (quoted) throw new Error('The class list contains an unclosed quote.');
 	if (
-		// Because reading rooms is not a all-public thing
-		(await supabase.from('rooms').select('*').eq('id', params.room!).single()).error?.code ===
-		'PGRST116'
+		rows[0]?.map((value) => value.toLowerCase()).join(',') === 'name,teacher_first,teacher_last'
 	) {
+		rows.shift();
+	}
+	return rows.map(([name, teacher_first, teacher_last], index) => {
+		if (!name || !teacher_first || !teacher_last) {
+			throw new Error(
+				`Class list row ${index + 1} needs name, teacher first name, and teacher last name.`
+			);
+		}
+		return { name, teacher_first, teacher_last };
+	});
+}
+
+async function requireToken(
+	room: string,
+	cookies: Parameters<Actions[string]>[0]['cookies'],
+	supabase: Parameters<Actions[string]>[0]['locals']['supabase']
+) {
+	const token = cookies.get(adminCookie(room));
+	if (!token) return null;
+	const { data, error } = await supabase.rpc('verify_room_admin', {
+		p_room: room,
+		p_token: token
+	});
+	return !error && data ? token : null;
+}
+
+export const load: ServerLoad = async ({ params, cookies, locals: { supabase } }) => {
+	const room = params.room!;
+	const roomResult = await supabase
+		.from('rooms')
+		.select('id, announcement, allow_class_creation, class_name_format, teacher_name_format')
+		.eq('id', room)
+		.single();
+	if (roomResult.error?.code === 'PGRST116') {
 		throw returnError(404, 'Room does not exist');
 	}
+	if (roomResult.error) throw roomResult.error;
 	// Surely not a N+1
-	const { data, error } = await supabase.from('schedules').select('*').eq('room', params.room!);
+	const [{ data, error }, classesResult, auditResult, token] = await Promise.all([
+		supabase.from('schedules').select('*').eq('room', room),
+		supabase.from('classes').select('*').eq('room', room),
+		supabase
+			.from('room_audit_log')
+			.select('*')
+			.eq('room', room)
+			.order('created_at', { ascending: false })
+			.limit(100),
+		requireToken(room, cookies, supabase)
+	]);
 
-	if (error !== null) {
-		throw error;
-	}
+	if (error) throw error;
+	if (classesResult.error) throw classesResult.error;
+	if (auditResult.error) throw auditResult.error;
 	return {
-		data
+		data,
+		classes: classesResult.data,
+		roomConfig: roomResult.data,
+		auditLog: auditResult.data,
+		isAdmin: token !== null
 	};
+};
+
+export const actions: Actions = {
+	login: async ({ params, request, cookies, url, locals: { supabase } }) => {
+		const room = params.room!;
+		const token = String((await request.formData()).get('token') ?? '').trim();
+		const { data } = await supabase.rpc('verify_room_admin', { p_room: room, p_token: token });
+		if (!data) return fail(403, { message: 'That admin credential is invalid.' });
+		cookies.set(adminCookie(room), token, cookieOptions(room, url.protocol === 'https:'));
+		throw redirect(303, url.pathname);
+	},
+	logout: async ({ params, cookies, url }) => {
+		cookies.delete(adminCookie(params.room!), { path: `/room/${params.room}` });
+		throw redirect(303, url.pathname);
+	},
+	settings: async ({ params, request, cookies, locals: { supabase } }) => {
+		const room = params.room!;
+		const token = await requireToken(room, cookies, supabase);
+		if (!token) return fail(403, { message: 'Admin authorization required.' });
+		const form = await request.formData();
+		const { error } = await supabase.rpc('admin_update_room', {
+			p_room: room,
+			p_token: token,
+			p_announcement: String(form.get('announcement') ?? ''),
+			p_allow_class_creation: form.get('allow_class_creation') === 'on',
+			p_class_name_format: String(form.get('class_name_format') ?? 'normalized'),
+			p_teacher_name_format: String(form.get('teacher_name_format') ?? 'title')
+		});
+		if (error) return fail(400, { message: error.message });
+		return { message: 'Room settings saved.' };
+	},
+	seed: async ({ params, request, cookies, locals: { supabase } }) => {
+		const room = params.room!;
+		const token = await requireToken(room, cookies, supabase);
+		if (!token) return fail(403, { message: 'Admin authorization required.' });
+		const form = await request.formData();
+		const uploaded = form.get('class_file');
+		let source = String(form.get('class_list') ?? '');
+		if (uploaded instanceof File && uploaded.size > 0) source = await uploaded.text();
+		try {
+			const classes = parseCsv(source);
+			if (classes.length === 0) return fail(400, { message: 'Add at least one class.' });
+			const { error } = await supabase.rpc('admin_seed_classes', {
+				p_room: room,
+				p_token: token,
+				p_classes: classes
+			});
+			if (error) return fail(400, { message: error.message });
+			return { message: `${classes.length} classes imported.` };
+		} catch (error) {
+			return fail(400, { message: error instanceof Error ? error.message : 'Invalid class list.' });
+		}
+	},
+	updateSchedule: async ({ params, request, cookies, locals: { supabase } }) => {
+		const room = params.room!;
+		const token = await requireToken(room, cookies, supabase);
+		if (!token) return fail(403, { message: 'Admin authorization required.' });
+		const form = await request.formData();
+		const student = String(form.get('original_student') ?? '');
+		const schedule = Object.fromEntries(
+			['student', '1a', '2a', '3a', '4a', '1b', '2b', '3b', '4b'].map((key) => [
+				key,
+				String(form.get(key) ?? '')
+			])
+		);
+		const { error } = await supabase.rpc('admin_update_schedule', {
+			p_room: room,
+			p_token: token,
+			p_student: student,
+			p_schedule: schedule
+		});
+		if (error) return fail(400, { message: error.message });
+		return { message: `${schedule.student}'s schedule updated.` };
+	},
+	deleteSchedule: async ({ params, request, cookies, locals: { supabase } }) => {
+		const room = params.room!;
+		const token = await requireToken(room, cookies, supabase);
+		if (!token) return fail(403, { message: 'Admin authorization required.' });
+		const student = String((await request.formData()).get('student') ?? '');
+		const { error } = await supabase.rpc('admin_delete_schedule', {
+			p_room: room,
+			p_token: token,
+			p_student: student
+		});
+		if (error) return fail(400, { message: error.message });
+		return { message: `${student}'s schedule deleted.` };
+	},
+	rotate: async ({ params, cookies, url, locals: { supabase } }) => {
+		const room = params.room!;
+		const token = await requireToken(room, cookies, supabase);
+		if (!token) return fail(403, { message: 'Admin authorization required.' });
+		const transferToken = newAdminToken();
+		const { error } = await supabase.rpc('admin_rotate_token', {
+			p_room: room,
+			p_token: token,
+			p_new_token: transferToken
+		});
+		if (error) return fail(400, { message: error.message });
+		cookies.set(adminCookie(room), transferToken, cookieOptions(room, url.protocol === 'https:'));
+		return { message: 'Credential rotated. The previous credential is revoked.', transferToken };
+	}
 };

--- a/src/routes/room/[room=uuid]/+page.svelte
+++ b/src/routes/room/[room=uuid]/+page.svelte
@@ -13,17 +13,20 @@
 	import { onMount } from 'svelte';
 
 	import type { VirtualSchedule, Classes, Class, Schedule } from '$lib/InfoInput.d';
-	import type { PageData } from './$types';
+	import type { ActionData, PageData } from './$types';
 	import memoize from 'lodash-es/memoize';
 	import ToastList from '$lib/ToastList.svelte';
 	import { addToast } from '$lib/toasts.svelte';
 	import { copyToClipboard } from '$lib/actions';
 	import type { You } from './ViewSchedules';
 	import Engineer from './Engineer.svelte';
+	import AdminPanel from './AdminPanel.svelte';
 
-	let { data }: { data: PageData } = $props();
+	let { data, form }: { data: PageData; form: ActionData | null } = $props();
 	let supabase = $derived(data.supabase);
 	let schedules: Schedule[] = $derived(data.data);
+	let roomConfig = $derived(data.roomConfig);
+	let auditLog = $derived(data.auditLog);
 	async function _getClass(id: string) {
 		const { data, error } = await supabase.from('classes').select('*').eq('id', id);
 		if (error !== null) {
@@ -33,24 +36,12 @@
 		return data![0];
 	}
 	const getClass = memoize(_getClass);
-	async function getClasses(room: string) {
-		return await supabase.from('classes').select('*').eq('room', room);
-	}
 	let you: You = $state()!;
-	let classes: Classes = $state([]);
+	let classes: Classes = $derived(data.classes);
 	let onlyMatching: boolean = $state(false);
 	let realtimeStatus: 'SUBSCRIBED' | 'TIMED_OUT' | 'CLOSED' | 'CHANNEL_ERROR' = $state('CLOSED');
 	let room = $derived(page.params.room!);
 	onMount(async () => {
-		{
-			const { data, error } = await getClasses(room);
-			// did not convert to console.assert
-			// to appease TypeScript
-			if (error !== null) {
-				throw error;
-			}
-			classes = data;
-		}
 		// Load it from localStorage
 		you = JSON.parse(window.localStorage.getItem(room) ?? 'null');
 		if (
@@ -98,15 +89,19 @@
 					if (payload.eventType === 'INSERT') {
 						schedules = [...schedules, payload.new];
 						addToast(`${payload.new.student} just added their schedule to this room`);
+					} else if (payload.eventType === 'UPDATE') {
+						schedules = schedules.map((schedule) =>
+							schedule.student === payload.old.student ? payload.new : schedule
+						);
+					} else if (payload.eventType === 'DELETE') {
+						schedules = schedules.filter((schedule) => schedule.student !== payload.old.student);
 					}
-					console.log('1', payload);
 				}
 			)
 			.on<Class>(
 				'postgres_changes',
 				{
-					// The only valid event (when I'm not clearing the db/devving)
-					event: 'INSERT',
+					event: '*',
 					schema: 'public',
 					table: 'classes',
 					// please don't let this be an SQL injection
@@ -116,7 +111,32 @@
 					filter: `room=eq.${sqlEscape(room)}`
 				},
 				async (payload) => {
-					classes = [...classes, payload.new];
+					if (payload.eventType === 'INSERT') classes = [...classes, payload.new];
+					if (payload.eventType === 'UPDATE') {
+						classes = classes.map((klass) => (klass.id === payload.old.id ? payload.new : klass));
+					}
+					if (payload.eventType === 'DELETE') {
+						classes = classes.filter((klass) => klass.id !== payload.old.id);
+					}
+				}
+			)
+			.on<typeof roomConfig>(
+				'postgres_changes',
+				{ event: 'UPDATE', schema: 'public', table: 'rooms', filter: `id=eq.${sqlEscape(room)}` },
+				(payload) => {
+					roomConfig = payload.new;
+				}
+			)
+			.on<(typeof auditLog)[number]>(
+				'postgres_changes',
+				{
+					event: 'INSERT',
+					schema: 'public',
+					table: 'room_audit_log',
+					filter: `room=eq.${sqlEscape(room)}`
+				},
+				(payload) => {
+					auditLog = [payload.new, ...auditLog].slice(0, 100);
 				}
 			)
 			.subscribe((status) => {
@@ -144,10 +164,30 @@
 		firstName: string;
 		lastName: string;
 	}) {
+		if (!roomConfig.allow_class_creation) {
+			addToast('Only a room admin may add classes in this room', 'error');
+			throw new Error('Visitor class creation is disabled');
+		}
+		const formattedClass =
+			roomConfig.class_name_format === 'normalized'
+				? normalize(className)
+				: roomConfig.class_name_format === 'title'
+					? className
+							.trim()
+							.toLowerCase()
+							.replace(/\b\w/g, (letter) => letter.toUpperCase())
+					: className.trim();
+		const formatTeacher = (name: string) =>
+			roomConfig.teacher_name_format === 'title'
+				? name
+						.trim()
+						.toLowerCase()
+						.replace(/\b\w/g, (letter) => letter.toUpperCase())
+				: name.trim();
 		const payload = {
-			name: normalize(className),
-			teacher_first: firstName.trim().toLowerCase(),
-			teacher_last: lastName.trim().toLowerCase(),
+			name: formattedClass,
+			teacher_first: formatTeacher(firstName),
+			teacher_last: formatTeacher(lastName),
 			room
 		};
 		const { data, error } = await supabase.from('classes').insert([payload]).select();
@@ -169,7 +209,14 @@
 		<div class="modal-box max-h-screen h-fit max-w-screen overflow-visible">
 			<h3 class="font-bold text-lg">But first...</h3>
 			<p class="py-4">Please enter your information</p>
-			<InfoInput onsubmit={onInfoSubmitted} {classes} {addClass} />
+			<InfoInput
+				onsubmit={onInfoSubmitted}
+				{classes}
+				{addClass}
+				canCreateClass={roomConfig.allow_class_creation}
+				classNameFormat={roomConfig.class_name_format}
+				teacherNameFormat={roomConfig.teacher_name_format}
+			/>
 			<button
 				class="btn btn-accent w-full my-4"
 				onclick={() => {
@@ -191,6 +238,11 @@
 			{schedules.length}
 			{schedules.length === 1 ? 'schedule' : 'schedules'} in this room so far
 		</p>
+		{#if roomConfig.announcement}
+			<div class="alert alert-info mt-3 max-w-2xl whitespace-pre-wrap">
+				{roomConfig.announcement}
+			</div>
+		{/if}
 		<!--
 			Button row
 		 -->
@@ -234,6 +286,30 @@
 					}}>Reset who you are</button
 				>
 			{/if}
+			{#if !data.isAdmin}
+				<details class="dropdown dropdown-end">
+					<summary class="btn btn-ghost">Room admin</summary>
+					<form
+						method="POST"
+						action="?/login"
+						class="card dropdown-content z-10 mt-2 w-80 border border-base-300 bg-base-100 shadow-xl"
+					>
+						<div class="card-body p-4">
+							<label class="form-control">
+								<span class="label-text">Admin credential</span>
+								<input
+									class="input input-bordered"
+									type="password"
+									name="token"
+									autocomplete="off"
+									required
+								/>
+							</label>
+							<button class="btn btn-primary" type="submit">Recover admin session</button>
+						</div>
+					</form>
+				</details>
+			{/if}
 		</div>
 		{#if room == 'a0ac4ff8-46aa-41a7-834a-9dc56cd0e06e'}
 			<div class="alert alert-info mx-auto mt-3 w-fit max-w-md text-sm">
@@ -274,5 +350,30 @@
 		<Engineer {schedules} />
 	</Tabs.Content>
 </Tabs.Root>
+
+{#if data.isAdmin}
+	<AdminPanel {roomConfig} {classes} {schedules} {auditLog} {form} />
+{:else}
+	<details
+		class="collapse collapse-arrow mx-auto my-8 w-11/12 max-w-5xl border border-base-300 bg-base-100"
+	>
+		<summary class="collapse-title text-xl font-medium">Public admin audit log</summary>
+		<div class="collapse-content overflow-x-auto">
+			<table class="table table-sm">
+				<thead><tr><th>Time</th><th>Change</th><th>Affected record</th></tr></thead>
+				<tbody>
+					{#each auditLog as entry (entry.id)}
+						<tr
+							><td>{new Date(entry.created_at).toLocaleString()}</td><td
+								>{entry.action} {entry.affected_table}</td
+							><td><code class="text-xs">{JSON.stringify(entry.affected_record)}</code></td></tr
+						>
+					{:else}<tr><td colspan="3">No admin changes yet.</td></tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</details>
+{/if}
 
 <Realtime {realtimeStatus} />

--- a/src/routes/room/[room=uuid]/AdminPanel.svelte
+++ b/src/routes/room/[room=uuid]/AdminPanel.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+	import type { Class, Schedule } from '$lib/InfoInput';
+
+	let {
+		roomConfig,
+		classes,
+		schedules,
+		auditLog,
+		form
+	}: {
+		roomConfig: {
+			announcement: string;
+			allow_class_creation: boolean;
+			class_name_format: string;
+			teacher_name_format: string;
+		};
+		classes: Class[];
+		schedules: Schedule[];
+		auditLog: Array<{
+			id: number;
+			created_at: string;
+			action: string;
+			affected_table: string;
+			affected_record: unknown;
+		}>;
+		form?: { message?: string; transferToken?: string } | null;
+	} = $props();
+
+	const periods = ['1a', '2a', '3a', '4a', '1b', '2b', '3b', '4b'] as const;
+</script>
+
+<section class="mx-auto my-8 w-11/12 max-w-5xl space-y-6">
+	<div class="flex flex-wrap items-center justify-between gap-3">
+		<div>
+			<h2 class="font-marker text-4xl font-bold">Room administration</h2>
+			<p class="opacity-70">Your admin session is stored securely on this device.</p>
+		</div>
+		<form method="POST" action="?/logout">
+			<button class="btn btn-ghost">Leave admin mode</button>
+		</form>
+	</div>
+
+	{#if form?.message}
+		<div class="alert alert-info"><span>{form.message}</span></div>
+	{/if}
+	{#if form?.transferToken}
+		<div class="alert alert-warning block">
+			<p class="font-bold">Copy this one-time transfer credential now.</p>
+			<p>
+				Entering it on another device transfers admin access. The old credential no longer works.
+			</p>
+			<code class="mt-2 block break-all select-all rounded bg-base-300 p-3"
+				>{form.transferToken}</code
+			>
+		</div>
+	{/if}
+
+	<div class="grid gap-6 lg:grid-cols-2">
+		<form method="POST" action="?/settings" class="card border border-base-300 bg-base-100 shadow">
+			<div class="card-body">
+				<h3 class="card-title">Room settings</h3>
+				<label class="form-control">
+					<span class="label-text">Announcement or naming guide</span>
+					<textarea class="textarea textarea-bordered" maxlength="2000" name="announcement"
+						>{roomConfig.announcement}</textarea
+					>
+				</label>
+				<label class="label cursor-pointer justify-start gap-3">
+					<input
+						class="toggle toggle-primary"
+						type="checkbox"
+						name="allow_class_creation"
+						checked={roomConfig.allow_class_creation}
+					/>
+					<span>Visitors may create classes</span>
+				</label>
+				<label class="form-control">
+					<span class="label-text">Class names</span>
+					<select
+						class="select select-bordered"
+						name="class_name_format"
+						value={roomConfig.class_name_format}
+					>
+						<option value="normalized">Normalized lowercase</option>
+						<option value="title">Title case</option>
+						<option value="preserve">Preserve input</option>
+					</select>
+				</label>
+				<label class="form-control">
+					<span class="label-text">Teacher names</span>
+					<select
+						class="select select-bordered"
+						name="teacher_name_format"
+						value={roomConfig.teacher_name_format}
+					>
+						<option value="title">Title case</option>
+						<option value="preserve">Preserve input</option>
+					</select>
+				</label>
+				<button class="btn btn-primary" type="submit">Save settings</button>
+			</div>
+		</form>
+
+		<form
+			method="POST"
+			action="?/seed"
+			enctype="multipart/form-data"
+			class="card border border-base-300 bg-base-100 shadow"
+		>
+			<div class="card-body">
+				<h3 class="card-title">Seed classes</h3>
+				<p class="text-sm opacity-70">
+					CSV columns: class name, teacher first name, teacher last name. A header is optional.
+				</p>
+				<textarea
+					class="textarea textarea-bordered min-h-32"
+					name="class_list"
+					placeholder="Biology,Jane,Doe&#10;Calculus,Alan,Turing"></textarea>
+				<label class="form-control">
+					<span class="label-text">Or upload a CSV file</span>
+					<input
+						class="file-input file-input-bordered"
+						type="file"
+						name="class_file"
+						accept=".csv,text/csv"
+					/>
+				</label>
+				<button class="btn btn-primary" type="submit">Import classes</button>
+			</div>
+		</form>
+	</div>
+
+	<div class="card border border-base-300 bg-base-100 shadow">
+		<div class="card-body">
+			<h3 class="card-title">Moderate schedules</h3>
+			{#each schedules as schedule (schedule.student)}
+				<details class="collapse collapse-arrow border border-base-300">
+					<summary class="collapse-title font-medium">{schedule.student}</summary>
+					<div class="collapse-content space-y-3">
+						<form method="POST" action="?/updateSchedule" class="space-y-3">
+							<input type="hidden" name="original_student" value={schedule.student} />
+							<input
+								class="input input-bordered w-full"
+								name="student"
+								value={schedule.student}
+								required
+							/>
+							<div class="grid grid-cols-2 gap-2 md:grid-cols-4">
+								{#each periods as period (period)}
+									<label class="form-control">
+										<span class="label-text uppercase">{period}</span>
+										<select
+											class="select select-bordered"
+											name={period}
+											value={schedule[period]}
+											required
+										>
+											{#each classes as klass (klass.id)}
+												<option value={klass.id}>{klass.name} — {klass.teacher_last}</option>
+											{/each}
+										</select>
+									</label>
+								{/each}
+							</div>
+							<button class="btn btn-primary" type="submit">Save schedule</button>
+						</form>
+						<form method="POST" action="?/deleteSchedule">
+							<input type="hidden" name="student" value={schedule.student} />
+							<button class="btn btn-error btn-outline" type="submit">Delete schedule</button>
+						</form>
+					</div>
+				</details>
+			{:else}
+				<p class="opacity-70">No schedules have been submitted.</p>
+			{/each}
+		</div>
+	</div>
+
+	<div class="card border border-base-300 bg-base-100 shadow">
+		<div class="card-body">
+			<h3 class="card-title">Transfer or revoke admin access</h3>
+			<p>
+				Rotating creates a new credential, revokes every previous copy, and keeps this device signed
+				in.
+			</p>
+			<form method="POST" action="?/rotate">
+				<button class="btn btn-warning" type="submit">Rotate and show transfer credential</button>
+			</form>
+		</div>
+	</div>
+
+	<div class="card border border-base-300 bg-base-100 shadow">
+		<div class="card-body">
+			<h3 class="card-title">Public audit log</h3>
+			<div class="overflow-x-auto">
+				<table class="table table-sm">
+					<thead><tr><th>Time</th><th>Action</th><th>Record</th></tr></thead>
+					<tbody>
+						{#each auditLog as entry (entry.id)}
+							<tr>
+								<td>{new Date(entry.created_at).toLocaleString()}</td>
+								<td>{entry.action} {entry.affected_table}</td>
+								<td><code class="text-xs">{JSON.stringify(entry.affected_record)}</code></td>
+							</tr>
+						{:else}
+							<tr><td colspan="3">No admin changes yet.</td></tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</section>

--- a/supabase/migrations/20260714234522_room_admins.sql
+++ b/supabase/migrations/20260714234522_room_admins.sql
@@ -1,0 +1,318 @@
+create schema if not exists private;
+
+revoke all on schema private from public, anon, authenticated;
+
+alter table public.rooms
+  add column announcement text not null default '',
+  add column allow_class_creation boolean not null default true,
+  add column class_name_format text not null default 'normalized'
+    check (class_name_format in ('normalized', 'title', 'preserve')),
+  add column teacher_name_format text not null default 'title'
+    check (teacher_name_format in ('title', 'preserve'));
+
+create table private.room_admins (
+  room uuid primary key references public.rooms(id) on delete cascade,
+  secret_hash text not null,
+  created_at timestamptz not null default now(),
+  rotated_at timestamptz
+);
+
+alter table private.room_admins enable row level security;
+revoke all on private.room_admins from public, anon, authenticated;
+
+create table public.room_audit_log (
+  id bigint generated always as identity primary key,
+  room uuid not null references public.rooms(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  action text not null,
+  affected_table text not null,
+  affected_record jsonb not null
+);
+
+alter table public.room_audit_log enable row level security;
+grant select on public.room_audit_log to anon, authenticated;
+grant all on public.room_audit_log to service_role;
+
+create policy "Room audit logs are public"
+on public.room_audit_log for select
+to anon, authenticated
+using (true);
+
+create or replace function private.valid_admin_token(p_room uuid, p_token text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select coalesce(
+    (select extensions.crypt(p_token, secret_hash) = secret_hash
+     from private.room_admins
+     where room = p_room),
+    false
+  );
+$$;
+
+revoke all on function private.valid_admin_token(uuid, text) from public, anon, authenticated;
+
+create or replace function private.require_admin(p_room uuid, p_token text)
+returns void
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+begin
+  if p_token is null or not private.valid_admin_token(p_room, p_token) then
+    raise exception 'Invalid room admin credential' using errcode = '42501';
+  end if;
+end;
+$$;
+
+revoke all on function private.require_admin(uuid, text) from public, anon, authenticated;
+
+create or replace function public.create_room_with_admin(p_id uuid, p_token text)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if length(p_token) < 32 then
+    raise exception 'Admin credential must contain at least 32 characters' using errcode = '22023';
+  end if;
+
+  insert into public.rooms (id) values (p_id);
+  insert into private.room_admins (room, secret_hash)
+    values (p_id, extensions.crypt(p_token, extensions.gen_salt('bf', 12)));
+  return p_id;
+end;
+$$;
+
+revoke all on function public.create_room_with_admin(uuid, text) from public;
+grant execute on function public.create_room_with_admin(uuid, text) to anon, authenticated;
+
+create or replace function public.verify_room_admin(p_room uuid, p_token text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select private.valid_admin_token(p_room, p_token);
+$$;
+
+revoke all on function public.verify_room_admin(uuid, text) from public;
+grant execute on function public.verify_room_admin(uuid, text) to anon, authenticated;
+
+create or replace function public.admin_update_room(
+  p_room uuid,
+  p_token text,
+  p_announcement text,
+  p_allow_class_creation boolean,
+  p_class_name_format text,
+  p_teacher_name_format text
+)
+returns public.rooms
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  changed public.rooms;
+begin
+  perform private.require_admin(p_room, p_token);
+  if p_class_name_format not in ('normalized', 'title', 'preserve')
+     or p_teacher_name_format not in ('title', 'preserve') then
+    raise exception 'Invalid display convention' using errcode = '22023';
+  end if;
+
+  update public.rooms
+  set announcement = left(coalesce(p_announcement, ''), 2000),
+      allow_class_creation = p_allow_class_creation,
+      class_name_format = p_class_name_format,
+      teacher_name_format = p_teacher_name_format
+  where id = p_room
+  returning * into changed;
+
+  insert into public.room_audit_log (room, action, affected_table, affected_record)
+  values (p_room, 'update', 'rooms', to_jsonb(changed));
+  return changed;
+end;
+$$;
+
+revoke all on function public.admin_update_room(uuid, text, text, boolean, text, text) from public;
+grant execute on function public.admin_update_room(uuid, text, text, boolean, text, text) to anon, authenticated;
+
+create or replace function public.admin_seed_classes(p_room uuid, p_token text, p_classes jsonb)
+returns setof public.classes
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  item jsonb;
+  inserted public.classes;
+  raw_name text;
+  raw_first text;
+  raw_last text;
+  name_format text;
+  teacher_format text;
+begin
+  perform private.require_admin(p_room, p_token);
+  if jsonb_typeof(p_classes) <> 'array' or jsonb_array_length(p_classes) > 1000 then
+    raise exception 'Classes must be an array of at most 1000 entries' using errcode = '22023';
+  end if;
+
+  select class_name_format, teacher_name_format
+  into name_format, teacher_format
+  from public.rooms where id = p_room;
+
+  for item in select value from jsonb_array_elements(p_classes)
+  loop
+    raw_name := btrim(coalesce(item->>'name', ''));
+    raw_first := btrim(coalesce(item->>'teacher_first', ''));
+    raw_last := btrim(coalesce(item->>'teacher_last', ''));
+    if raw_name = '' or raw_first = '' or raw_last = '' then
+      raise exception 'Every class requires name, teacher_first, and teacher_last' using errcode = '22023';
+    end if;
+
+    if name_format = 'normalized' then
+      raw_name := lower(regexp_replace(raw_name, '\s+', ' ', 'g'));
+      raw_name := regexp_replace(raw_name, ' iii$', ' 3', 'i');
+      raw_name := regexp_replace(raw_name, ' ii$', ' 2', 'i');
+      raw_name := regexp_replace(raw_name, ' i$', ' 1', 'i');
+    elsif name_format = 'title' then
+      raw_name := initcap(lower(regexp_replace(raw_name, '\s+', ' ', 'g')));
+    end if;
+
+    if teacher_format = 'title' then
+      raw_first := initcap(lower(raw_first));
+      raw_last := initcap(lower(raw_last));
+    end if;
+
+    insert into public.classes (name, teacher_first, teacher_last, room)
+    values (raw_name, raw_first, raw_last, p_room)
+    on conflict (name, teacher_first, teacher_last, room) do update set name = excluded.name
+    returning * into inserted;
+
+    insert into public.room_audit_log (room, action, affected_table, affected_record)
+    values (p_room, 'seed', 'classes', to_jsonb(inserted));
+    return next inserted;
+  end loop;
+end;
+$$;
+
+revoke all on function public.admin_seed_classes(uuid, text, jsonb) from public;
+grant execute on function public.admin_seed_classes(uuid, text, jsonb) to anon, authenticated;
+
+create or replace function public.admin_update_schedule(
+  p_room uuid,
+  p_token text,
+  p_student text,
+  p_schedule jsonb
+)
+returns public.schedules
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  changed public.schedules;
+  new_student text := btrim(coalesce(p_schedule->>'student', p_student));
+begin
+  perform private.require_admin(p_room, p_token);
+  if new_student = '' then
+    raise exception 'Student name is required' using errcode = '22023';
+  end if;
+
+  update public.schedules set
+    student = new_student,
+    "1a" = (p_schedule->>'1a')::uuid,
+    "2a" = (p_schedule->>'2a')::uuid,
+    "3a" = (p_schedule->>'3a')::uuid,
+    "4a" = (p_schedule->>'4a')::uuid,
+    "1b" = (p_schedule->>'1b')::uuid,
+    "2b" = (p_schedule->>'2b')::uuid,
+    "3b" = (p_schedule->>'3b')::uuid,
+    "4b" = (p_schedule->>'4b')::uuid
+  where room = p_room and student = p_student
+  returning * into changed;
+
+  if changed is null then
+    raise exception 'Schedule not found' using errcode = 'P0002';
+  end if;
+  insert into public.room_audit_log (room, action, affected_table, affected_record)
+  values (p_room, 'update', 'schedules', to_jsonb(changed));
+  return changed;
+end;
+$$;
+
+revoke all on function public.admin_update_schedule(uuid, text, text, jsonb) from public;
+grant execute on function public.admin_update_schedule(uuid, text, text, jsonb) to anon, authenticated;
+
+create or replace function public.admin_delete_schedule(p_room uuid, p_token text, p_student text)
+returns public.schedules
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  removed public.schedules;
+begin
+  perform private.require_admin(p_room, p_token);
+  delete from public.schedules
+  where room = p_room and student = p_student
+  returning * into removed;
+  if removed is null then
+    raise exception 'Schedule not found' using errcode = 'P0002';
+  end if;
+  insert into public.room_audit_log (room, action, affected_table, affected_record)
+  values (p_room, 'delete', 'schedules', to_jsonb(removed));
+  return removed;
+end;
+$$;
+
+revoke all on function public.admin_delete_schedule(uuid, text, text) from public;
+grant execute on function public.admin_delete_schedule(uuid, text, text) to anon, authenticated;
+
+create or replace function public.admin_rotate_token(p_room uuid, p_token text, p_new_token text)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  perform private.require_admin(p_room, p_token);
+  if length(p_new_token) < 32 then
+    raise exception 'Admin credential must contain at least 32 characters' using errcode = '22023';
+  end if;
+  update private.room_admins
+  set secret_hash = extensions.crypt(p_new_token, extensions.gen_salt('bf', 12)), rotated_at = now()
+  where room = p_room;
+  insert into public.room_audit_log (room, action, affected_table, affected_record)
+  values (p_room, 'rotate credential', 'room_admins', jsonb_build_object('room', p_room));
+  return true;
+end;
+$$;
+
+revoke all on function public.admin_rotate_token(uuid, text, text) from public;
+grant execute on function public.admin_rotate_token(uuid, text, text) to anon, authenticated;
+
+drop policy "Enable insertion for all users" on public.classes;
+create policy "Room settings allow class creation"
+on public.classes for insert
+to anon, authenticated
+with check (
+  exists (
+    select 1 from public.rooms
+    where rooms.id = classes.room and rooms.allow_class_creation
+  )
+);
+
+alter table public.rooms replica identity full;
+alter table public.schedules replica identity full;
+alter table public.room_audit_log replica identity full;
+
+alter publication supabase_realtime add table public.rooms;
+alter publication supabase_realtime add table public.room_audit_log;

--- a/supabase/tests/room_admins.test.sql
+++ b/supabase/tests/room_admins.test.sql
@@ -1,0 +1,127 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+select plan(12);
+
+select is(
+  public.create_room_with_admin(
+    '00000000-0000-0000-0000-000000000018'::uuid,
+    'original-admin-token-that-is-long-enough-18'
+  ),
+  '00000000-0000-0000-0000-000000000018'::uuid,
+  'a room can be created with an admin credential'
+);
+
+select ok(
+  public.verify_room_admin(
+    '00000000-0000-0000-0000-000000000018'::uuid,
+    'original-admin-token-that-is-long-enough-18'
+  ),
+  'the correct admin credential verifies'
+);
+
+select ok(
+  not public.verify_room_admin(
+    '00000000-0000-0000-0000-000000000018'::uuid,
+    'incorrect-admin-token-that-is-long-enough'
+  ),
+  'an incorrect admin credential is rejected'
+);
+
+select throws_ok(
+  $$
+    select public.admin_update_room(
+      '00000000-0000-0000-0000-000000000018'::uuid,
+      'incorrect-admin-token-that-is-long-enough',
+      'nope', false, 'preserve', 'preserve'
+    )
+  $$,
+  '42501',
+  'Invalid room admin credential',
+  'non-admin room mutations are rejected'
+);
+
+select lives_ok(
+  $$
+    select public.admin_update_room(
+      '00000000-0000-0000-0000-000000000018'::uuid,
+      'original-admin-token-that-is-long-enough-18',
+      'Follow the naming guide', false, 'title', 'preserve'
+    )
+  $$,
+  'an admin can update room settings'
+);
+
+select results_eq(
+  $$ select announcement, allow_class_creation, class_name_format, teacher_name_format
+     from public.rooms where id = '00000000-0000-0000-0000-000000000018'::uuid $$,
+  $$ values ('Follow the naming guide'::text, false, 'title'::text, 'preserve'::text) $$,
+  'room settings are stored with safe, enumerated conventions'
+);
+
+select is(
+  (
+    select count(*)
+    from public.admin_seed_classes(
+      '00000000-0000-0000-0000-000000000018'::uuid,
+      'original-admin-token-that-is-long-enough-18',
+      '[{"name":"biology ii","teacher_first":"jANE","teacher_last":"dOE"}]'::jsonb
+    )
+  ),
+  1::bigint,
+  'an admin can seed classes'
+);
+
+select results_eq(
+  $$ select name, teacher_first, teacher_last from public.classes
+     where room = '00000000-0000-0000-0000-000000000018'::uuid $$,
+  $$ values ('Biology Ii'::text, 'jANE'::text, 'dOE'::text) $$,
+  'seeded classes use the configured safe display conventions'
+);
+
+insert into public.schedules (room, student, "1a", "2a", "3a", "4a", "1b", "2b", "3b", "4b")
+select
+  '00000000-0000-0000-0000-000000000018'::uuid,
+  'Student One', id, id, id, id, id, id, id, id
+from public.classes
+where room = '00000000-0000-0000-0000-000000000018'::uuid;
+
+select lives_ok(
+  $$
+    select public.admin_delete_schedule(
+      '00000000-0000-0000-0000-000000000018'::uuid,
+      'original-admin-token-that-is-long-enough-18',
+      'Student One'
+    )
+  $$,
+  'an admin can delete a schedule'
+);
+
+select ok(
+  public.admin_rotate_token(
+    '00000000-0000-0000-0000-000000000018'::uuid,
+    'original-admin-token-that-is-long-enough-18',
+    'replacement-admin-token-that-is-long-enough'
+  ),
+  'an admin can rotate the credential'
+);
+
+select ok(
+  not public.verify_room_admin(
+    '00000000-0000-0000-0000-000000000018'::uuid,
+    'original-admin-token-that-is-long-enough-18'
+  ) and public.verify_room_admin(
+    '00000000-0000-0000-0000-000000000018'::uuid,
+    'replacement-admin-token-that-is-long-enough'
+  ),
+  'rotation revokes the old credential'
+);
+
+select ok(
+  (select count(*) >= 4 from public.room_audit_log
+   where room = '00000000-0000-0000-0000-000000000018'::uuid),
+  'admin mutations create public audit records'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

- issue unguessable, device-persistent room admin credentials backed by private salted hashes
- enforce every admin mutation in trusted database functions and keep ordinary visitor permissions backward-compatible
- add room announcements, class-creation controls, safe naming conventions, CSV class seeding, schedule editing/deletion, credential transfer/rotation, and a public audit log
- publish room settings, schedule edits/deletions, and audit entries through Supabase Realtime
- add pgTAP coverage for authorization, settings, class seeding, moderation, auditing, and credential revocation

## Security model

Admin credentials are stored only in an HttpOnly, same-site device cookie. The database stores a bcrypt hash in an RLS-protected private schema; neither the credential nor its hash is part of the public room payload. Each privileged RPC validates the credential before mutating data, and public table policies continue to permit only the existing submission paths plus visitor class creation when enabled by the room.

## Verification

- `pnpm lint`
- `PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 PUBLIC_SUPABASE_ANON_KEY=test-key pnpm build`
- `PLAYWRIGHT_PORT=4183 PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 PUBLIC_SUPABASE_ANON_KEY=test-key pnpm test`
- applied every migration to a clean local PostgreSQL database configured with Supabase roles/extensions, then exercised valid/invalid admin checks, settings, class seeding, audit records, and credential rotation/revocation

`pnpm check` still reports the two pre-existing type errors in `src/lib/engineer.ts`; the production build and changed files pass.

Closes #18
