### PR TITLE
Fix CI Supabase type generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
           node-version: 24
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
-      - name: Setup Supabase v2.33.5
+      - name: Setup Supabase v2.108.0
         uses: supabase/setup-cli@v1
         with:
-          version: 2.33.5
+          version: 2.108.0
       - name: Install dependencies
         run: |
           pnpm install
@@ -54,10 +54,10 @@ jobs:
           node-version: 24
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
-      - name: Setup Supabase v2.33.5
+      - name: Setup Supabase v2.108.0
         uses: supabase/setup-cli@v1
         with:
-          version: 2.33.5
+          version: 2.108.0
       - name: Install dependencies
         run: pnpm install
       - name: Start database
@@ -68,9 +68,11 @@ jobs:
         run: |
           supabase gen types typescript --local > src/lib/supabase.d.ts
           if ! git diff --ignore-space-at-eol --exit-code --quiet src/lib/supabase.d.ts; then
-              echo "Detected uncommitted changes after build. See status below:" >> $GITHUB_STEP_SUMMARY
-              echo "```diff" >> >> $GITHUB_STEP_SUMMARY
-              echo $(git diff) >> $GITHUB_STEP_SUMMARY
-              echo "```" >> $GITHUB_STEP_SUMMARY
+              {
+                echo "Detected uncommitted changes after build. See status below:"
+                echo '```diff'
+                git diff -- src/lib/supabase.d.ts
+                echo '```'
+              } >> "$GITHUB_STEP_SUMMARY"
               exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
           supabase db reset
       - name: Set environment variables
         run: |
-          supabase status --output env | node convert_env.js > .env || test -s .env
+          supabase status --output env > .env.supabase
+          node convert_env.js < .env.supabase > .env
+          rm .env.supabase
           test -s .env
       - name: Install again, just in case
         run: npx playwright install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,9 @@ jobs:
           supabase start
           supabase db reset
       - name: Set environment variables
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          timeout_minutes: 1
-          command: |
-            supabase status --output env | node convert_env.js > .env
-            test -s .env
+        run: |
+          supabase status --output env | node convert_env.js > .env || test -s .env
+          test -s .env
       - name: Install again, just in case
         run: npx playwright install
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Verify generated types match Postgres schema
         run: |
           supabase gen types typescript --local > src/lib/supabase.d.ts
+          node -e "const fs=require('node:fs'); const p='src/lib/supabase.d.ts'; fs.writeFileSync(p, fs.readFileSync(p, 'utf8').trimEnd() + '\n');"
           if ! git diff --ignore-space-at-eol --exit-code --quiet src/lib/supabase.d.ts; then
               {
                 echo "Detected uncommitted changes after build. See status below:"

--- a/convert_env.js
+++ b/convert_env.js
@@ -17,9 +17,15 @@ const REMAP = {
 	ANON_KEY: 'PUBLIC_SUPABASE_ANON_KEY',
 	SERVICE_ROLE_KEY: 'PUBLIC_SUPABASE_SERVICE_ROLE_KEY'
 };
-for (let keyValue of stdin.matchAll(/(\w+)="(.+)"/gm)) {
-	const key = keyValue[1];
-	const value = keyValue[2];
+
+let entries;
+try {
+	entries = Object.entries(JSON.parse(stdin));
+} catch {
+	entries = [...stdin.matchAll(/(\w+)="(.+)"/gm)].map((match) => [match[1], match[2]]);
+}
+
+for (const [key, value] of entries) {
 	if (Object.prototype.hasOwnProperty.call(REMAP, key)) {
 		console.log(`${REMAP[key]}=${value}`);
 	} else {

--- a/src/lib/supabase.d.ts
+++ b/src/lib/supabase.d.ts
@@ -7,10 +7,30 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instanciate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "12.2.12 (cd3cf9e)"
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
   }
   public: {
     Tables: {
@@ -298,6 +318,9 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {},
   },


### PR DESCRIPTION
## Summary

- align both GitHub Actions jobs with Supabase CLI 2.108.0
- refresh the committed database type snapshot from a clean, isolated Supabase 2.108.0 stack
- normalize the generated file ending before comparing it with the committed snapshot
- repair the generated-type diff summary written to the Actions step summary
- avoid the Supabase CLI wrapper's piped-output crash when exporting local environment variables

## Root cause

Every branch inherited two failures from `main`. CI used Supabase CLI 2.33.5 while the local stack and schema snapshot had moved forward, so `check-types` always found a generated diff. After aligning the CLI, the test job exposed a wrapper bug that crashes when `supabase status` is piped directly into another process.

The environment export now writes Supabase's output to a temporary file before converting it, and still fails if the final `.env` is empty.

## Validation

- generated `src/lib/supabase.d.ts` from a clean isolated Supabase 2.108.0 stack
- verified both env and JSON conversion paths in `convert_env.js`
- `pnpm exec prettier --check .github/workflows/ci.yml convert_env.js`
- `git diff --check`
- GitHub Actions `check-types`: passed
- GitHub Actions Playwright `test`: passed
- Vercel deployment: passed
