### PR TITLE
Replace schedule OCR with Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ More in the [screenshot gallery](./docs/SCREENSHOTS.md).
 - **🌗 Chalkboard mode** — dark mode swaps the paper for a dusty chalkboard, following your system preference automatically.
 - **🧠 Remembers you** — your identity per room is stored locally, so you only enter your schedule once.
 - **✏️ Private editing** — update your name or classes later with a room-scoped edit key that never appears in the public room data.
-- **📷 AI-assisted import** — use Gemma 4 to extract a schedule from a screenshot, then review every class before applying it.
+- **📷 AI-assisted import** — use Gemini to extract a schedule from a screenshot, then review every class before applying it.
 
 ## 🏫 How it works
 
@@ -105,13 +105,17 @@ testing, and deployment.
 Screenshot import additionally requires a server-only Google AI API key:
 
 ```dotenv
-GEMMA_API_KEY=your-google-ai-api-key
-# Optional; defaults to gemma-4-26b-a4b-it
-GEMMA_MODEL=gemma-4-26b-a4b-it
+GEMINI_API_KEY=your-google-ai-api-key
+# Optional; defaults to the stable Gemini 3.6 Flash model
+GEMINI_MODEL=gemini-3.6-flash
 ```
 
-Never expose `GEMMA_API_KEY` through a `PUBLIC_` environment variable. Without it, pasted-text
+Never expose `GEMINI_API_KEY` through a `PUBLIC_` environment variable. Without it, pasted-text
 import continues to work and the screenshot endpoint returns a configuration error.
+
+Google's free Gemini API tier may use submitted content to improve its products; its paid tier says
+submitted content is not used for that purpose. Review the current Gemini API data-use terms before
+enabling screenshot import, especially for student data.
 
 ### Useful scripts
 
@@ -143,7 +147,7 @@ src/
 │   └── room/[room=uuid]/ # The room: view, search, and compare schedules
 │       └── components/   #   Route-local schedule entry UI
 │           ├── InfoInput.svelte       # Schedule entry form
-│           ├── ScheduleImporter.svelte # Gemma screenshot and browser-local text import
+│           ├── ScheduleImporter.svelte # Gemini screenshot and browser-local text import
 │           └── ClassPicker.svelte     # Searchable class dropdown
 supabase/
 ├── migrations/           # Database schema

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ More in the [screenshot gallery](./docs/SCREENSHOTS.md).
 - **🌗 Chalkboard mode** — dark mode swaps the paper for a dusty chalkboard, following your system preference automatically.
 - **🧠 Remembers you** — your identity per room is stored locally, so you only enter your schedule once.
 - **✏️ Private editing** — update your name or classes later with a room-scoped edit key that never appears in the public room data.
+- **📷 AI-assisted import** — use Gemma 4 to extract a schedule from a screenshot, then review every class before applying it.
 
 ## 🏫 How it works
 
@@ -101,6 +102,17 @@ server-only service-role key used by database-backed tests. See the
 [development guide](./docs/DEVELOPMENT.md) for troubleshooting, migrations, generated types,
 testing, and deployment.
 
+Screenshot import additionally requires a server-only Google AI API key:
+
+```dotenv
+GEMMA_API_KEY=your-google-ai-api-key
+# Optional; defaults to gemma-4-26b-a4b-it
+GEMMA_MODEL=gemma-4-26b-a4b-it
+```
+
+Never expose `GEMMA_API_KEY` through a `PUBLIC_` environment variable. Without it, pasted-text
+import continues to work and the screenshot endpoint returns a configuration error.
+
 ### Useful scripts
 
 | Command                       | What it does                                      |
@@ -131,7 +143,7 @@ src/
 │   └── room/[room=uuid]/ # The room: view, search, and compare schedules
 │       └── components/   #   Route-local schedule entry UI
 │           ├── InfoInput.svelte       # Schedule entry form
-│           ├── ScheduleImporter.svelte # Browser-local screenshot/text import
+│           ├── ScheduleImporter.svelte # Gemma screenshot and browser-local text import
 │           └── ClassPicker.svelte     # Searchable class dropdown
 supabase/
 ├── migrations/           # Database schema

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,7 @@ client, and Postgres row-level security (RLS) is the authorization boundary.
    on the room's `classes` and `schedules` rows, and refreshes both tables from Postgres.
 4. `InfoInput.svelte` requires a student name and one distinct class UUID for each of the eight A/B
    periods. `ClassPicker.svelte` can select an existing room class or insert a normalized class.
-   `ScheduleImporter.svelte` can prefill the same form from pasted text or Gemma-assisted
+   `ScheduleImporter.svelte` can prefill the same form from pasted text or Gemini-assisted
    screenshot extraction; the user reviews matches and confirms the completed form before
    submission.
 5. The room page calls the `create_schedule` security-definer function. It inserts one `schedules`
@@ -191,12 +191,12 @@ filter predicates.
 
 `ScheduleImporter.svelte` accepts PNG, JPEG, or WebP files up to 10 MB, pasted images, or pasted
 text. Pasted text is parsed locally. Screenshots are posted to `/api/schedule-import`, which keeps
-the Google AI API key server-only, sends the image to Gemma 4, and validates the structured result
+the Google AI API key server-only, sends the image to Gemini, and validates the structured result
 before returning it. Responses are not cached, and the endpoint applies a best-effort per-instance
 rate limit. Wuzursched does not intentionally retain source images after the request.
 
 For pasted text, `src/lib/scheduleImport.ts` extracts rows labeled `1A` through `4B` and parses
-class and teacher text, including dotted titles such as `Dr.`. Gemma screenshot output enters the
+class and teacher text, including dotted titles such as `Dr.`. Gemini screenshot output enters the
 pipeline as the same `ScheduleCandidate` shape. Both paths compare candidates with the room's
 classes using normalized Levenshtein similarity weighted 72% toward the class and 28% toward the
 teacher. Scores at least 0.82 are selected automatically; scores from 0.5 to 0.82 are suggestions;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,15 +10,15 @@ Wuzursched is a SvelteKit application backed directly by Supabase Postgres. Ther
 account or application API layer: server loads and browser components both use the public Supabase
 client, and Postgres row-level security (RLS) is the authorization boundary.
 
-| Concern                 | Source of truth                        | Main code                                                                                       |
-| ----------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Supabase clients        | Public URL and anonymous key           | `src/hooks.server.ts`, `src/routes/+layout.ts`                                                  |
-| Room creation           | `rooms` row                            | `src/routes/create/+server.ts`                                                                  |
-| Initial room data       | Server load plus usage-count RPC       | `src/routes/room/[room=uuid]/+page.server.ts`, `get_classes_with_usage`                          |
-| Classes and submissions | `classes` and `schedules` tables       | The room route's `components/InfoInput.svelte` and `components/ClassPicker.svelte`              |
-| Browser identity        | Room-keyed `localStorage` value        | `src/routes/room/[room=uuid]/+page.svelte`                                                      |
-| Live updates            | Supabase Realtime publications         | The room page, `src/lib/realtime.ts`, and `supabase/migrations/20240715235333_add_realtime.sql` |
-| Comparison UI           | Same class UUID in the same period     | `ViewSchedules.svelte`, `ScheduleDisplay.svelte`, `Search.svelte`                               |
+| Concern                 | Source of truth                    | Main code                                                                                       |
+| ----------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Supabase clients        | Public URL and anonymous key       | `src/hooks.server.ts`, `src/routes/+layout.ts`                                                  |
+| Room creation           | `rooms` row                        | `src/routes/create/+server.ts`                                                                  |
+| Initial room data       | Server load plus usage-count RPC   | `src/routes/room/[room=uuid]/+page.server.ts`, `get_classes_with_usage`                         |
+| Classes and submissions | `classes` and `schedules` tables   | The room route's `components/InfoInput.svelte` and `components/ClassPicker.svelte`              |
+| Browser identity        | Room-keyed `localStorage` value    | `src/routes/room/[room=uuid]/+page.svelte`                                                      |
+| Live updates            | Supabase Realtime publications     | The room page, `src/lib/realtime.ts`, and `supabase/migrations/20240715235333_add_realtime.sql` |
+| Comparison UI           | Same class UUID in the same period | `ViewSchedules.svelte`, `ScheduleDisplay.svelte`, `Search.svelte`                               |
 
 ## Room lifecycle and data path
 
@@ -32,8 +32,9 @@ client, and Postgres row-level security (RLS) is the authorization boundary.
    on the room's `classes` and `schedules` rows, and refreshes both tables from Postgres.
 4. `InfoInput.svelte` requires a student name and one distinct class UUID for each of the eight A/B
    periods. `ClassPicker.svelte` can select an existing room class or insert a normalized class.
-   `ScheduleImporter.svelte` can prefill the same form from pasted text or browser-local screenshot
-   OCR; the user reviews matches and confirms the completed form before submission.
+   `ScheduleImporter.svelte` can prefill the same form from pasted text or Gemma-assisted
+   screenshot extraction; the user reviews matches and confirms the completed form before
+   submission.
 5. The room page calls the `create_schedule` security-definer function. It inserts one `schedules`
    row plus a private hash of a newly generated edit key, then returns the unhashed key once to the
    submitting browser. The schedule stores the room and student plus eight foreign keys into
@@ -189,16 +190,19 @@ filter predicates.
 ## Schedule screenshot and text import
 
 `ScheduleImporter.svelte` accepts PNG, JPEG, or WebP files up to 10 MB, pasted images, or pasted
-text. Tesseract OCR runs in the browser: the image is not uploaded to Wuzursched or an OCR service,
-though the worker may download its language model. The source image is discarded after processing.
+text. Pasted text is parsed locally. Screenshots are posted to `/api/schedule-import`, which keeps
+the Google AI API key server-only, sends the image to Gemma 4, and validates the structured result
+before returning it. Responses are not cached, and the endpoint applies a best-effort per-instance
+rate limit. Wuzursched does not intentionally retain source images after the request.
 
-`src/lib/scheduleImport.ts` extracts rows labeled `1A` through `4B`, parses class and teacher text
-(including dotted titles such as `Dr.`), and compares candidates with the room's classes using
-normalized Levenshtein similarity weighted 72% toward the class and 28% toward the teacher. Scores
-at least 0.82 are selected automatically; scores from 0.5 to 0.82 are suggestions; lower scores are
-unresolved. Users can edit every row, choose a room class, or explicitly approve creation of
-unmatched classes. Applying an import only prefills the normal schedule form; the separate review
-checkbox still gates schedule submission.
+For pasted text, `src/lib/scheduleImport.ts` extracts rows labeled `1A` through `4B` and parses
+class and teacher text, including dotted titles such as `Dr.`. Gemma screenshot output enters the
+pipeline as the same `ScheduleCandidate` shape. Both paths compare candidates with the room's
+classes using normalized Levenshtein similarity weighted 72% toward the class and 28% toward the
+teacher. Scores at least 0.82 are selected automatically; scores from 0.5 to 0.82 are suggestions;
+lower scores are unresolved. Users can edit every row, choose a room class, or explicitly approve
+creation of unmatched classes. Applying an import only prefills the normal schedule form; the
+separate review checkbox still gates schedule submission.
 
 ## Schedule-engineering algorithm
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
 		"clsx": "^2.1.1",
 		"mode-watcher": "^1.1.0",
 		"tailwind-merge": "^3.6.0",
-		"tailwind-variants": "^3.2.2",
-		"tesseract.js": "^7.0.0"
+		"tailwind-variants": "^3.2.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ importers:
       tailwind-variants:
         specifier: ^3.2.2
         version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
-      tesseract.js:
-        specifier: ^7.0.0
-        version: 7.0.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -1058,9 +1055,6 @@ packages:
       '@internationalized/date': ^3.8.1
       svelte: ^5.33.0
 
-  bmp-js@0.1.0:
-    resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
-
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
@@ -1353,9 +1347,6 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  idb-keyval@6.3.0:
-    resolution: {integrity: sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==}
-
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
@@ -1384,9 +1375,6 @@ packages:
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
-
-  is-url@1.2.4:
-    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1568,25 +1556,12 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   nwsapi@2.2.24:
     resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
 
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
-
-  opencollective-postinstall@2.0.3:
-    resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
-    hasBin: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1700,9 +1675,6 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
-
-  regenerator-runtime@0.13.11:
-    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
@@ -1850,12 +1822,6 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tesseract.js-core@7.0.0:
-    resolution: {integrity: sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==}
-
-  tesseract.js@7.0.0:
-    resolution: {integrity: sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1892,9 +1858,6 @@ packages:
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
-
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
@@ -2062,12 +2025,6 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  wasm-feature-detect@1.8.0:
-    resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -2084,9 +2041,6 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2131,9 +2085,6 @@ packages:
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
-
-  zlibjs@0.3.1:
-    resolution: {integrity: sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==}
 
 snapshots:
 
@@ -2892,8 +2843,6 @@ snapshots:
     transitivePeerDependencies:
       - '@sveltejs/kit'
 
-  bmp-js@0.1.0: {}
-
   brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
@@ -3189,8 +3138,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  idb-keyval@6.3.0: {}
-
   ignore@5.3.1: {}
 
   ignore@7.0.6: {}
@@ -3210,8 +3157,6 @@ snapshots:
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
-
-  is-url@1.2.4: {}
 
   isexe@2.0.0: {}
 
@@ -3362,15 +3307,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   nwsapi@2.2.24: {}
 
   obug@2.1.3: {}
-
-  opencollective-postinstall@2.0.3: {}
 
   optionator@0.9.4:
     dependencies:
@@ -3461,8 +3400,6 @@ snapshots:
   react-is@17.0.2: {}
 
   readdirp@4.1.2: {}
-
-  regenerator-runtime@0.13.11: {}
 
   rolldown@1.1.5:
     dependencies:
@@ -3659,22 +3596,6 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tesseract.js-core@7.0.0: {}
-
-  tesseract.js@7.0.0:
-    dependencies:
-      bmp-js: 0.1.0
-      idb-keyval: 6.3.0
-      is-url: 1.2.4
-      node-fetch: 2.7.0
-      opencollective-postinstall: 2.0.3
-      regenerator-runtime: 0.13.11
-      tesseract.js-core: 7.0.0
-      wasm-feature-detect: 1.8.0
-      zlibjs: 0.3.1
-    transitivePeerDependencies:
-      - encoding
-
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -3701,8 +3622,6 @@ snapshots:
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
-
-  tr46@0.0.3: {}
 
   tr46@5.1.1:
     dependencies:
@@ -3837,10 +3756,6 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  wasm-feature-detect@1.8.0: {}
-
-  webidl-conversions@3.0.1: {}
-
   webidl-conversions@7.0.0: {}
 
   whatwg-encoding@3.1.1:
@@ -3853,11 +3768,6 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:
@@ -3881,5 +3791,3 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zimmerframe@1.1.4: {}
-
-  zlibjs@0.3.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,8 +7,6 @@ allowBuilds:
   '@sveltejs/kit': true
   esbuild: true
   svelte-preprocess: true
-  # Only runs an optional OpenCollective message; OCR works without it.
-  tesseract.js: false
 onlyBuiltDependencies:
   - '@sveltejs/kit'
   - esbuild

--- a/src/lib/scheduleImport.ts
+++ b/src/lib/scheduleImport.ts
@@ -70,7 +70,7 @@ function parseDetails(value: string) {
 	return { className, ...splitTeacher(teacher) };
 }
 
-/** Extracts schedule rows from OCR output or pasted text without retaining the source image. */
+/** Extracts schedule rows from pasted or previously recognized text. */
 export function extractScheduleCandidates(text: string): ScheduleCandidate[] {
 	const candidates = new Map<ImportPeriod, ScheduleCandidate>();
 	const lines = text

--- a/src/lib/server/geminiScheduleImport.ts
+++ b/src/lib/server/geminiScheduleImport.ts
@@ -2,7 +2,7 @@ import { IMPORT_PERIODS, type ImportPeriod, type ScheduleCandidate } from '../sc
 
 const GEMINI_API_ROOT = 'https://generativelanguage.googleapis.com/v1beta/models';
 
-export const DEFAULT_GEMMA_MODEL = 'gemma-4-26b-a4b-it';
+export const DEFAULT_GEMINI_MODEL = 'gemini-3.6-flash';
 
 export const SCHEDULE_EXTRACTION_PROMPT = `Read this student schedule screenshot and extract every visible class row.
 
@@ -52,12 +52,12 @@ type GeminiResponse = {
 	error?: { message?: string };
 };
 
-export class GemmaScheduleImportError extends Error {
+export class GeminiScheduleImportError extends Error {
 	readonly kind: 'configuration' | 'upstream' | 'invalid-output';
 
 	constructor(message: string, kind: 'configuration' | 'upstream' | 'invalid-output') {
 		super(message);
-		this.name = 'GemmaScheduleImportError';
+		this.name = 'GeminiScheduleImportError';
 		this.kind = kind;
 	}
 }
@@ -67,16 +67,16 @@ function clean(value: string) {
 }
 
 /** Treat model output as untrusted input and reduce it to the app's schedule domain. */
-export function validateGemmaScheduleRows(value: unknown): ScheduleCandidate[] {
+export function validateGeminiScheduleRows(value: unknown): ScheduleCandidate[] {
 	if (!Array.isArray(value)) {
-		throw new GemmaScheduleImportError('Gemma returned an invalid schedule.', 'invalid-output');
+		throw new GeminiScheduleImportError('Gemini returned an invalid schedule.', 'invalid-output');
 	}
 
 	const rows = new Map<ImportPeriod, ScheduleCandidate>();
 	for (const item of value) {
 		if (typeof item !== 'object' || item === null) {
-			throw new GemmaScheduleImportError(
-				'Gemma returned an invalid schedule row.',
+			throw new GeminiScheduleImportError(
+				'Gemini returned an invalid schedule row.',
 				'invalid-output'
 			);
 		}
@@ -87,8 +87,8 @@ export function validateGemmaScheduleRows(value: unknown): ScheduleCandidate[] {
 			typeof record.teacherFirst !== 'string' ||
 			typeof record.teacherLast !== 'string'
 		) {
-			throw new GemmaScheduleImportError(
-				'Gemma returned an incomplete schedule row.',
+			throw new GeminiScheduleImportError(
+				'Gemini returned an incomplete schedule row.',
 				'invalid-output'
 			);
 		}
@@ -96,8 +96,8 @@ export function validateGemmaScheduleRows(value: unknown): ScheduleCandidate[] {
 		const period = record.period.toLowerCase() as ImportPeriod;
 		const className = clean(record.className);
 		if (!IMPORT_PERIODS.includes(period) || !className) {
-			throw new GemmaScheduleImportError(
-				'Gemma returned an unsupported schedule row.',
+			throw new GeminiScheduleImportError(
+				'Gemini returned an unsupported schedule row.',
 				'invalid-output'
 			);
 		}
@@ -116,9 +116,9 @@ export function validateGemmaScheduleRows(value: unknown): ScheduleCandidate[] {
 	});
 }
 
-export async function extractScheduleWithGemma({
+export async function extractScheduleWithGemini({
 	apiKey,
-	model = DEFAULT_GEMMA_MODEL,
+	model = DEFAULT_GEMINI_MODEL,
 	image,
 	fetcher = fetch
 }: {
@@ -128,7 +128,10 @@ export async function extractScheduleWithGemma({
 	fetcher?: typeof fetch;
 }): Promise<ScheduleCandidate[]> {
 	if (!apiKey) {
-		throw new GemmaScheduleImportError('Gemma schedule import is not configured.', 'configuration');
+		throw new GeminiScheduleImportError(
+			'Gemini schedule import is not configured.',
+			'configuration'
+		);
 	}
 
 	const bytes = new Uint8Array(await image.arrayBuffer());
@@ -151,10 +154,8 @@ export async function extractScheduleWithGemma({
 					}
 				],
 				generationConfig: {
-					thinkingConfig: { thinkingLevel: 'minimal' },
 					responseMimeType: 'application/json',
-					responseSchema,
-					temperature: 0
+					responseSchema
 				}
 			})
 		}
@@ -164,12 +165,12 @@ export async function extractScheduleWithGemma({
 	try {
 		payload = (await response.json()) as GeminiResponse;
 	} catch {
-		throw new GemmaScheduleImportError('Gemma returned an unreadable response.', 'upstream');
+		throw new GeminiScheduleImportError('Gemini returned an unreadable response.', 'upstream');
 	}
 
 	if (!response.ok) {
-		throw new GemmaScheduleImportError(
-			payload.error?.message || 'Gemma could not process this image.',
+		throw new GeminiScheduleImportError(
+			payload.error?.message || 'Gemini could not process this image.',
 			'upstream'
 		);
 	}
@@ -179,13 +180,13 @@ export async function extractScheduleWithGemma({
 		.join('')
 		.trim();
 	if (!text) {
-		throw new GemmaScheduleImportError('Gemma did not find a schedule.', 'invalid-output');
+		throw new GeminiScheduleImportError('Gemini did not find a schedule.', 'invalid-output');
 	}
 
 	try {
-		return validateGemmaScheduleRows(JSON.parse(text));
+		return validateGeminiScheduleRows(JSON.parse(text));
 	} catch (error) {
-		if (error instanceof GemmaScheduleImportError) throw error;
-		throw new GemmaScheduleImportError('Gemma returned invalid JSON.', 'invalid-output');
+		if (error instanceof GeminiScheduleImportError) throw error;
+		throw new GeminiScheduleImportError('Gemini returned invalid JSON.', 'invalid-output');
 	}
 }

--- a/src/lib/server/gemmaScheduleImport.ts
+++ b/src/lib/server/gemmaScheduleImport.ts
@@ -1,0 +1,191 @@
+import { IMPORT_PERIODS, type ImportPeriod, type ScheduleCandidate } from '../scheduleImport.ts';
+
+const GEMINI_API_ROOT = 'https://generativelanguage.googleapis.com/v1beta/models';
+
+export const DEFAULT_GEMMA_MODEL = 'gemma-4-26b-a4b-it';
+
+export const SCHEDULE_EXTRACTION_PROMPT = `Read this student schedule screenshot and extract every visible class row.
+
+Rules:
+- Return only periods 1A, 2A, 3A, 4A, 1B, 2B, 3B, and 4B.
+- Preserve the visible class name.
+- Split the teacher into first name or title and last name.
+- Supported titles include Mr, Mrs, Ms, Mx, Dr, and Coach.
+- Use an empty string for a teacher field that is not visible.
+- Do not invent missing rows or text.
+- If the screenshot contains multiple schedules, extract only the primary student schedule.`;
+
+const responseSchema = {
+	type: 'ARRAY',
+	items: {
+		type: 'OBJECT',
+		properties: {
+			period: {
+				type: 'STRING',
+				enum: IMPORT_PERIODS,
+				description: 'The normalized A/B schedule period.'
+			},
+			className: {
+				type: 'STRING',
+				description: 'The class or course name visible in this period.'
+			},
+			teacherFirst: {
+				type: 'STRING',
+				description: 'The teacher first name or supported title, without a trailing period.'
+			},
+			teacherLast: {
+				type: 'STRING',
+				description: 'The teacher last name.'
+			}
+		},
+		required: ['period', 'className', 'teacherFirst', 'teacherLast'],
+		propertyOrdering: ['period', 'className', 'teacherFirst', 'teacherLast']
+	}
+} as const;
+
+type GeminiResponse = {
+	candidates?: Array<{
+		content?: {
+			parts?: Array<{ text?: string }>;
+		};
+	}>;
+	error?: { message?: string };
+};
+
+export class GemmaScheduleImportError extends Error {
+	readonly kind: 'configuration' | 'upstream' | 'invalid-output';
+
+	constructor(message: string, kind: 'configuration' | 'upstream' | 'invalid-output') {
+		super(message);
+		this.name = 'GemmaScheduleImportError';
+		this.kind = kind;
+	}
+}
+
+function clean(value: string) {
+	return value.replace(/\s+/g, ' ').trim();
+}
+
+/** Treat model output as untrusted input and reduce it to the app's schedule domain. */
+export function validateGemmaScheduleRows(value: unknown): ScheduleCandidate[] {
+	if (!Array.isArray(value)) {
+		throw new GemmaScheduleImportError('Gemma returned an invalid schedule.', 'invalid-output');
+	}
+
+	const rows = new Map<ImportPeriod, ScheduleCandidate>();
+	for (const item of value) {
+		if (typeof item !== 'object' || item === null) {
+			throw new GemmaScheduleImportError(
+				'Gemma returned an invalid schedule row.',
+				'invalid-output'
+			);
+		}
+		const record = item as Record<string, unknown>;
+		if (
+			typeof record.period !== 'string' ||
+			typeof record.className !== 'string' ||
+			typeof record.teacherFirst !== 'string' ||
+			typeof record.teacherLast !== 'string'
+		) {
+			throw new GemmaScheduleImportError(
+				'Gemma returned an incomplete schedule row.',
+				'invalid-output'
+			);
+		}
+
+		const period = record.period.toLowerCase() as ImportPeriod;
+		const className = clean(record.className);
+		if (!IMPORT_PERIODS.includes(period) || !className) {
+			throw new GemmaScheduleImportError(
+				'Gemma returned an unsupported schedule row.',
+				'invalid-output'
+			);
+		}
+
+		rows.set(period, {
+			period,
+			className,
+			teacherFirst: clean(record.teacherFirst).replace(/\.$/, ''),
+			teacherLast: clean(record.teacherLast)
+		});
+	}
+
+	return IMPORT_PERIODS.flatMap((period) => {
+		const row = rows.get(period);
+		return row ? [row] : [];
+	});
+}
+
+export async function extractScheduleWithGemma({
+	apiKey,
+	model = DEFAULT_GEMMA_MODEL,
+	image,
+	fetcher = fetch
+}: {
+	apiKey: string;
+	model?: string;
+	image: Pick<File, 'type' | 'arrayBuffer'>;
+	fetcher?: typeof fetch;
+}): Promise<ScheduleCandidate[]> {
+	if (!apiKey) {
+		throw new GemmaScheduleImportError('Gemma schedule import is not configured.', 'configuration');
+	}
+
+	const bytes = new Uint8Array(await image.arrayBuffer());
+	const response = await fetcher(
+		`${GEMINI_API_ROOT}/${encodeURIComponent(model)}:generateContent`,
+		{
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				'x-goog-api-key': apiKey
+			},
+			body: JSON.stringify({
+				contents: [
+					{
+						role: 'user',
+						parts: [
+							{ inlineData: { mimeType: image.type, data: Buffer.from(bytes).toString('base64') } },
+							{ text: SCHEDULE_EXTRACTION_PROMPT }
+						]
+					}
+				],
+				generationConfig: {
+					thinkingConfig: { thinkingLevel: 'minimal' },
+					responseMimeType: 'application/json',
+					responseSchema,
+					temperature: 0
+				}
+			})
+		}
+	);
+
+	let payload: GeminiResponse;
+	try {
+		payload = (await response.json()) as GeminiResponse;
+	} catch {
+		throw new GemmaScheduleImportError('Gemma returned an unreadable response.', 'upstream');
+	}
+
+	if (!response.ok) {
+		throw new GemmaScheduleImportError(
+			payload.error?.message || 'Gemma could not process this image.',
+			'upstream'
+		);
+	}
+
+	const text = payload.candidates?.[0]?.content?.parts
+		?.map((part) => part.text ?? '')
+		.join('')
+		.trim();
+	if (!text) {
+		throw new GemmaScheduleImportError('Gemma did not find a schedule.', 'invalid-output');
+	}
+
+	try {
+		return validateGemmaScheduleRows(JSON.parse(text));
+	} catch (error) {
+		if (error instanceof GemmaScheduleImportError) throw error;
+		throw new GemmaScheduleImportError('Gemma returned invalid JSON.', 'invalid-output');
+	}
+}

--- a/src/routes/api/schedule-import/+server.ts
+++ b/src/routes/api/schedule-import/+server.ts
@@ -1,9 +1,9 @@
 import { env } from '$env/dynamic/private';
 import {
-	DEFAULT_GEMMA_MODEL,
-	extractScheduleWithGemma,
-	GemmaScheduleImportError
-} from '$lib/server/gemmaScheduleImport';
+	DEFAULT_GEMINI_MODEL,
+	extractScheduleWithGemini,
+	GeminiScheduleImportError
+} from '$lib/server/geminiScheduleImport';
 import { MAX_SCHEDULE_IMAGE_SIZE, validateScheduleImage } from '$lib/scheduleImport';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
@@ -24,7 +24,7 @@ function isRateLimited(address: string, now = Date.now()) {
 }
 
 export const POST: RequestHandler = async ({ request, getClientAddress, fetch }) => {
-	if (!env.GEMMA_API_KEY) {
+	if (!env.GEMINI_API_KEY) {
 		return json(
 			{ error: 'Screenshot import is not configured on this deployment.' },
 			{ status: 503, headers: { 'cache-control': 'no-store' } }
@@ -72,17 +72,17 @@ export const POST: RequestHandler = async ({ request, getClientAddress, fetch })
 	}
 
 	try {
-		const rows = await extractScheduleWithGemma({
-			apiKey: env.GEMMA_API_KEY,
-			model: env.GEMMA_MODEL || DEFAULT_GEMMA_MODEL,
+		const rows = await extractScheduleWithGemini({
+			apiKey: env.GEMINI_API_KEY,
+			model: env.GEMINI_MODEL || DEFAULT_GEMINI_MODEL,
 			image,
 			fetcher: fetch
 		});
 		return json({ rows }, { headers: { 'cache-control': 'no-store' } });
 	} catch (error) {
-		console.error('Gemma schedule import failed', error);
+		console.error('Gemini schedule import failed', error);
 		const status =
-			error instanceof GemmaScheduleImportError && error.kind === 'invalid-output' ? 422 : 502;
+			error instanceof GeminiScheduleImportError && error.kind === 'invalid-output' ? 422 : 502;
 		return json(
 			{
 				error:

--- a/src/routes/api/schedule-import/+server.ts
+++ b/src/routes/api/schedule-import/+server.ts
@@ -1,0 +1,96 @@
+import { env } from '$env/dynamic/private';
+import {
+	DEFAULT_GEMMA_MODEL,
+	extractScheduleWithGemma,
+	GemmaScheduleImportError
+} from '$lib/server/gemmaScheduleImport';
+import { MAX_SCHEDULE_IMAGE_SIZE, validateScheduleImage } from '$lib/scheduleImport';
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+const WINDOW_MS = 10 * 60 * 1000;
+const MAX_REQUESTS_PER_WINDOW = 5;
+const attempts = new Map<string, number[]>();
+
+function isRateLimited(address: string, now = Date.now()) {
+	const recent = (attempts.get(address) ?? []).filter((timestamp) => now - timestamp < WINDOW_MS);
+	if (recent.length >= MAX_REQUESTS_PER_WINDOW) {
+		attempts.set(address, recent);
+		return true;
+	}
+	recent.push(now);
+	attempts.set(address, recent);
+	return false;
+}
+
+export const POST: RequestHandler = async ({ request, getClientAddress, fetch }) => {
+	if (!env.GEMMA_API_KEY) {
+		return json(
+			{ error: 'Screenshot import is not configured on this deployment.' },
+			{ status: 503, headers: { 'cache-control': 'no-store' } }
+		);
+	}
+
+	if (isRateLimited(getClientAddress())) {
+		return json(
+			{ error: 'Too many screenshot imports. Please wait a few minutes and try again.' },
+			{ status: 429, headers: { 'cache-control': 'no-store', 'retry-after': '600' } }
+		);
+	}
+
+	const contentLength = Number(request.headers.get('content-length'));
+	if (Number.isFinite(contentLength) && contentLength > MAX_SCHEDULE_IMAGE_SIZE + 1024 * 1024) {
+		return json(
+			{ error: 'The image must be 10 MB or smaller.' },
+			{ status: 413, headers: { 'cache-control': 'no-store' } }
+		);
+	}
+
+	let form: FormData;
+	try {
+		form = await request.formData();
+	} catch {
+		return json(
+			{ error: 'Upload a PNG, JPEG, or WebP schedule image.' },
+			{ status: 400, headers: { 'cache-control': 'no-store' } }
+		);
+	}
+
+	const image = form.get('image');
+	if (!(image instanceof File)) {
+		return json(
+			{ error: 'Upload a PNG, JPEG, or WebP schedule image.' },
+			{ status: 400, headers: { 'cache-control': 'no-store' } }
+		);
+	}
+	const validationError = validateScheduleImage(image);
+	if (validationError) {
+		return json(
+			{ error: validationError },
+			{ status: 400, headers: { 'cache-control': 'no-store' } }
+		);
+	}
+
+	try {
+		const rows = await extractScheduleWithGemma({
+			apiKey: env.GEMMA_API_KEY,
+			model: env.GEMMA_MODEL || DEFAULT_GEMMA_MODEL,
+			image,
+			fetcher: fetch
+		});
+		return json({ rows }, { headers: { 'cache-control': 'no-store' } });
+	} catch (error) {
+		console.error('Gemma schedule import failed', error);
+		const status =
+			error instanceof GemmaScheduleImportError && error.kind === 'invalid-output' ? 422 : 502;
+		return json(
+			{
+				error:
+					status === 422
+						? 'We could not find a usable schedule in that image. Try a clearer screenshot.'
+						: 'The schedule-reading service is temporarily unavailable.'
+			},
+			{ status, headers: { 'cache-control': 'no-store' } }
+		);
+	}
+};

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -73,11 +73,12 @@
 				<h3 class="mt-5 text-2xl font-bold">AI-assisted screenshot import</h3>
 				<p class="mt-2">
 					If you choose to import a schedule screenshot, Wuzursched sends the image to Google’s
-					Gemma service to extract class, period, and teacher information. Wuzursched processes the
+					Gemini service to extract class, period, and teacher information. Wuzursched processes the
 					image in memory for this request and does not intentionally retain it after processing.
 					Google may process the image and related technical information under its applicable
-					service terms and privacy commitments. You can avoid this processing by entering or
-					pasting schedule information manually.
+					service terms and privacy commitments. Depending on the service tier used by the
+					Wuzursched deployment, Google may use submitted content to improve its products. You can
+					avoid this processing by entering or pasting schedule information manually.
 				</p>
 			</section>
 

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -17,7 +17,7 @@
 		<header class="rounded-box border border-base-300 bg-base-100 p-6 shadow-sm md:p-8">
 			<p class="text-lg opacity-70">What Wuzursched knows and why</p>
 			<h1 class="mt-1 text-5xl font-bold md:text-6xl">Privacy Policy</h1>
-			<p class="mt-3 font-semibold">Effective July 14, 2026</p>
+			<p class="mt-3 font-semibold">Effective July 30, 2026</p>
 		</header>
 
 		<div class="mt-8 space-y-8 rounded-box bg-base-100 p-6 shadow-sm md:p-10">
@@ -69,6 +69,16 @@
 					authentication, hosting, and network services. Wuzursched does not currently use
 					advertising cookies or sell personal information.
 				</p>
+
+				<h3 class="mt-5 text-2xl font-bold">AI-assisted screenshot import</h3>
+				<p class="mt-2">
+					If you choose to import a schedule screenshot, Wuzursched sends the image to Google’s
+					Gemma service to extract class, period, and teacher information. Wuzursched processes the
+					image in memory for this request and does not intentionally retain it after processing.
+					Google may process the image and related technical information under its applicable
+					service terms and privacy commitments. You can avoid this processing by entering or
+					pasting schedule information manually.
+				</p>
 			</section>
 
 			<section>
@@ -76,6 +86,9 @@
 				<p class="mt-2">We use information to:</p>
 				<ul class="mt-2 list-disc space-y-1 pl-6">
 					<li>create rooms and display, compare, search, and update schedules in realtime;</li>
+					<li>
+						extract schedule information from screenshots when you request AI-assisted import;
+					</li>
 					<li>remember your identity within a room on your device;</li>
 					<li>operate, troubleshoot, secure, maintain, and improve the service;</li>
 					<li>respond to questions, abuse reports, and deletion requests; and</li>
@@ -95,6 +108,11 @@
 					and realtime data. Vercel hosts and delivers the application and may process request and diagnostic
 					logs. They process information to provide services to Wuzursched under their applicable terms
 					and privacy commitments.
+				</p>
+				<p class="mt-3">
+					<strong>AI processing.</strong> Google processes schedule screenshots only when you choose AI-assisted
+					screenshot import. The extracted results are returned for your review before they are applied
+					to the schedule form.
 				</p>
 				<p class="mt-3">
 					<strong>Legal and safety reasons.</strong> We may preserve or disclose information when reasonably

--- a/src/routes/room/[room=uuid]/components/ScheduleImporter.svelte
+++ b/src/routes/room/[room=uuid]/components/ScheduleImporter.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
 	import type { UnfinishedSchedule } from '$lib/schedule';
 	import type { Classes } from '../types';
@@ -37,7 +38,6 @@
 	let rows: PreviewRow[] = $state([]);
 	let error = $state('');
 	let processing = $state(false);
-	let progress = $state(0);
 	let confirmCreates = $state(false);
 	let applying = $state(false);
 	let hasUnresolved = $derived(rows.some((row) => !row.selectedClassId));
@@ -66,26 +66,29 @@
 		error = validateScheduleImage(file);
 		if (error) return;
 		processing = true;
-		progress = 0;
-		let worker: Awaited<ReturnType<(typeof import('tesseract.js'))['createWorker']>> | undefined;
 		try {
-			const { createWorker } = await import('tesseract.js');
-			worker = await createWorker('eng', 1, {
-				logger: (message) => {
-					if (typeof message.progress === 'number') progress = Math.round(message.progress * 100);
-				}
+			const form = new FormData();
+			form.set('image', file);
+			const response = await fetch(resolve('/api/schedule-import'), {
+				method: 'POST',
+				body: form
 			});
-			const result = await worker.recognize(file);
-			sourceText = result.data.text;
-			preview(extractScheduleCandidates(sourceText));
+			const result = (await response.json()) as {
+				rows?: ScheduleCandidate[];
+				error?: string;
+			};
+			if (!response.ok || !result.rows) {
+				throw new Error(result.error || 'The schedule-reading service returned an error.');
+			}
+			preview(result.rows);
 		} catch (reason) {
 			console.error(reason);
 			error =
-				'We could not read that image. Try a clearer screenshot or paste the schedule as text.';
+				reason instanceof Error
+					? reason.message
+					: 'We could not read that image. Try a clearer screenshot or paste the schedule as text.';
 		} finally {
-			await worker?.terminate();
 			processing = false;
-			progress = 0;
 		}
 	}
 
@@ -170,8 +173,10 @@
 		</form>
 		<h3 class="text-3xl font-bold">Import your schedule</h3>
 		<p class="mt-2 text-sm">
-			Your image is read locally in this browser and is never uploaded to Wuzursched or an OCR
-			service. It is discarded as soon as processing finishes. OCR may download its language model.
+			Screenshots are securely sent to Google’s Gemma service for AI-assisted reading and are not
+			intentionally retained by Wuzursched after the request. Review every result before applying
+			it. Pasted text is processed locally in your browser. See our
+			<a href={resolve('/privacy')} class="link">Privacy Policy</a>.
 		</p>
 
 		<label class="mt-4 block">
@@ -192,8 +197,8 @@
 
 		{#if processing}
 			<div class="my-4" role="status">
-				<progress class="progress progress-primary w-full" value={progress} max="100"></progress>
-				<p>Reading image… {progress}%</p>
+				<progress class="progress progress-primary w-full"></progress>
+				<p>Reading image with Gemma…</p>
 			</div>
 		{/if}
 

--- a/src/routes/room/[room=uuid]/components/ScheduleImporter.svelte
+++ b/src/routes/room/[room=uuid]/components/ScheduleImporter.svelte
@@ -173,7 +173,7 @@
 		</form>
 		<h3 class="text-3xl font-bold">Import your schedule</h3>
 		<p class="mt-2 text-sm">
-			Screenshots are securely sent to Google’s Gemma service for AI-assisted reading and are not
+			Screenshots are securely sent to Google’s Gemini service for AI-assisted reading and are not
 			intentionally retained by Wuzursched after the request. Review every result before applying
 			it. Pasted text is processed locally in your browser. See our
 			<a href={resolve('/privacy')} class="link">Privacy Policy</a>.
@@ -198,7 +198,7 @@
 		{#if processing}
 			<div class="my-4" role="status">
 				<progress class="progress progress-primary w-full"></progress>
-				<p>Reading image with Gemma…</p>
+				<p>Reading image with Gemini…</p>
 			</div>
 		{/if}
 

--- a/tests/schedule-import.unit.ts
+++ b/tests/schedule-import.unit.ts
@@ -8,10 +8,10 @@ import {
 	validateScheduleImage
 } from '../src/lib/scheduleImport.ts';
 import {
-	extractScheduleWithGemma,
-	GemmaScheduleImportError,
-	validateGemmaScheduleRows
-} from '../src/lib/server/gemmaScheduleImport.ts';
+	extractScheduleWithGemini,
+	GeminiScheduleImportError,
+	validateGeminiScheduleRows
+} from '../src/lib/server/geminiScheduleImport.ts';
 
 const fixtures = new URL('./fixtures/schedule-import/', import.meta.url);
 
@@ -105,9 +105,9 @@ describe('schedule import', () => {
 		assert.equal(validateScheduleImage({ type: 'image/jpeg', size: 10 * 1024 * 1024 }), '');
 	});
 
-	it('validates, normalizes, de-duplicates, and orders Gemma rows', () => {
+	it('validates, normalizes, de-duplicates, and orders Gemini rows', () => {
 		assert.deepEqual(
-			validateGemmaScheduleRows([
+			validateGeminiScheduleRows([
 				{
 					period: '2B',
 					className: '  English   10 ',
@@ -144,19 +144,19 @@ describe('schedule import', () => {
 		);
 	});
 
-	it('rejects semantically invalid Gemma rows', () => {
+	it('rejects semantically invalid Gemini rows', () => {
 		assert.throws(
 			() =>
-				validateGemmaScheduleRows([
+				validateGeminiScheduleRows([
 					{ period: '5a', className: 'Biology', teacherFirst: 'Jane', teacherLast: 'Smith' }
 				]),
-			GemmaScheduleImportError
+			GeminiScheduleImportError
 		);
 	});
 
-	it('sends the image to Gemma and validates its structured response', async () => {
+	it('sends the image to Gemini and validates its structured response', async () => {
 		let request: { url: string; init?: RequestInit } | undefined;
-		const rows = await extractScheduleWithGemma({
+		const rows = await extractScheduleWithGemini({
 			apiKey: 'server-secret',
 			image: {
 				type: 'image/png',
@@ -188,6 +188,7 @@ describe('schedule import', () => {
 		});
 
 		assert.equal(request?.url.endsWith(':generateContent'), true);
+		assert.equal(request?.url.includes('/gemini-3.6-flash:'), true);
 		assert.equal(new Headers(request?.init?.headers).get('x-goog-api-key'), 'server-secret');
 		assert.equal(request?.url.includes('server-secret'), false);
 		assert.deepEqual(

--- a/tests/schedule-import.unit.ts
+++ b/tests/schedule-import.unit.ts
@@ -7,6 +7,11 @@ import {
 	toUnfinishedSchedule,
 	validateScheduleImage
 } from '../src/lib/scheduleImport.ts';
+import {
+	extractScheduleWithGemma,
+	GemmaScheduleImportError,
+	validateGemmaScheduleRows
+} from '../src/lib/server/gemmaScheduleImport.ts';
 
 const fixtures = new URL('./fixtures/schedule-import/', import.meta.url);
 
@@ -98,5 +103,99 @@ describe('schedule import', () => {
 		assert.match(validateScheduleImage({ type: 'application/pdf', size: 1 }), /PNG/);
 		assert.match(validateScheduleImage({ type: 'image/png', size: 10 * 1024 * 1024 + 1 }), /10 MB/);
 		assert.equal(validateScheduleImage({ type: 'image/jpeg', size: 10 * 1024 * 1024 }), '');
+	});
+
+	it('validates, normalizes, de-duplicates, and orders Gemma rows', () => {
+		assert.deepEqual(
+			validateGemmaScheduleRows([
+				{
+					period: '2B',
+					className: '  English   10 ',
+					teacherFirst: 'Dr.',
+					teacherLast: ' Lee '
+				},
+				{
+					period: '1a',
+					className: 'Biology',
+					teacherFirst: 'Jane',
+					teacherLast: 'Smith'
+				},
+				{
+					period: '1A',
+					className: 'AP Biology',
+					teacherFirst: 'Jane',
+					teacherLast: 'Smith'
+				}
+			]),
+			[
+				{
+					period: '1a',
+					className: 'AP Biology',
+					teacherFirst: 'Jane',
+					teacherLast: 'Smith'
+				},
+				{
+					period: '2b',
+					className: 'English 10',
+					teacherFirst: 'Dr',
+					teacherLast: 'Lee'
+				}
+			]
+		);
+	});
+
+	it('rejects semantically invalid Gemma rows', () => {
+		assert.throws(
+			() =>
+				validateGemmaScheduleRows([
+					{ period: '5a', className: 'Biology', teacherFirst: 'Jane', teacherLast: 'Smith' }
+				]),
+			GemmaScheduleImportError
+		);
+	});
+
+	it('sends the image to Gemma and validates its structured response', async () => {
+		let request: { url: string; init?: RequestInit } | undefined;
+		const rows = await extractScheduleWithGemma({
+			apiKey: 'server-secret',
+			image: {
+				type: 'image/png',
+				arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer
+			},
+			fetcher: async (input, init) => {
+				request = { url: String(input), init };
+				return Response.json({
+					candidates: [
+						{
+							content: {
+								parts: [
+									{
+										text: JSON.stringify([
+											{
+												period: '1a',
+												className: 'Biology',
+												teacherFirst: 'Jane',
+												teacherLast: 'Smith'
+											}
+										])
+									}
+								]
+							}
+						}
+					]
+				});
+			}
+		});
+
+		assert.equal(request?.url.endsWith(':generateContent'), true);
+		assert.equal(new Headers(request?.init?.headers).get('x-goog-api-key'), 'server-secret');
+		assert.equal(request?.url.includes('server-secret'), false);
+		assert.deepEqual(
+			rows.map((row) => row.period),
+			['1a']
+		);
+		const body = JSON.parse(String(request?.init?.body));
+		assert.equal(body.contents[0].parts[0].inlineData.data, 'AQID');
+		assert.equal(body.generationConfig.responseMimeType, 'application/json');
 	});
 });


### PR DESCRIPTION
## What changed

- Replace browser-local Tesseract OCR with a server-side Gemini vision extraction endpoint using stable gemini-3.6-flash.
- Request constrained JSON rows and validate all model output before it enters the existing room-class matching and review flow.
- Keep pasted-text import local and deterministic.
- Keep GEMINI_API_KEY server-only, use no-store responses, validate upload type and size, and add a best-effort per-instance rate limit.
- Remove the Tesseract dependency and document GEMINI_API_KEY and optional GEMINI_MODEL configuration.
- Update the importer disclosure, privacy policy, and architecture documentation, including the free-tier versus paid-tier data-use distinction.

## Why

A hosted Gemini model gives this hosted integration stronger first-party multimodal support and native structured output. It can reason about varied schedule layouts and return the application schedule-row shape directly while preserving human review and existing submission safeguards.

## Deployment impact

Screenshot import requires a server-only GEMINI_API_KEY. GEMINI_MODEL is optional and defaults to gemini-3.6-flash. Without the key, pasted-text import still works and screenshot import returns a configuration error. Google states that free-tier content may be used to improve its products, while paid-tier content is not; paid configuration is recommended for production student data.

## Validation

- pnpm test:unit — passed, including component, import, and 26 Playwright unit tests.
- pnpm test:docs — passed.
- pnpm check — passed with one existing CSS compatibility warning.
- pnpm build — passed.
- Scoped ESLint and Prettier checks for all changed source and test files — passed.

The repository-wide pnpm lint currently stops on an unchanged formatting issue in playwright.config.ts on main; this PR does not modify that file.