### PR TITLE
Add Valley Christian 2027 schedule shortcut button

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -40,6 +40,14 @@
 					</div>
 					<a href={resolve('/create')} class="btn btn-primary">Create a room</a>
 				</div>
+				<a
+					href={resolve('/room/[room=uuid]', {
+						room: '9a7e704d-7772-435e-8af4-a258b1c68ebd'
+					})}
+					class="btn btn-secondary mt-3"
+				>
+					Valley Christian High School 2027 Schedule
+				</a>
 			</div>
 			<a href={resolve('/credits')} class="link">Credits to our beta testers</a>
 		</div>


### PR DESCRIPTION
## What

Adds a button to the landing page — directly below the join / create-a-room row — that links straight to the **Valley Christian High School class of 2027** schedule room (`/room/9a7e704d-7772-435e-8af4-a258b1c68ebd`).

## Why

The vast majority of Wuzursched's users are VCHS students (an estimated ~95%), and the site is already introduced as *"From the Valley Christian Software Development Club."* Sharing that room today means passing around the full UUID room URL. A one-click shortcut on the homepage means we can just point people at the site and have them tap the **Valley Christian High School 2027 Schedule** button instead of copy-pasting a long link.

## Implementation

- Single change in `src/routes/+page.svelte`.
- Uses the existing `resolve('/room/[room=uuid]', { room })` helper — the same pattern as the other internal links (`Create a room`, `Credits`) — so base-path handling and route typing stay consistent.
- Styled as `btn btn-secondary` so it reads as distinct from the primary **Join** / **Create a room** buttons, and it picks up the existing light/dark daisyUI themes automatically.

```svelte
<a
	href={resolve('/room/[room=uuid]', {
		room: '9a7e704d-7772-435e-8af4-a258b1c68ebd'
	})}
	class="btn btn-secondary mt-3"
>
	Valley Christian High School 2027 Schedule
</a>
```

## Notes / testing

- Verified locally with `pnpm run check` (no new type errors), `prettier` (formatted), and `pnpm run test:docs` (passing).
- Rendered locally in both light and dark mode — the button sits between the join/create row and the "Credits" link.
- The existing landing-page e2e flow (`tests/room.spec.ts`) targets **Create a room** by name and the **Join a room** placeholder, so the new link doesn't collide with those selectors.

Happy to adjust the copy, placement, or styling — or gate it behind config if you'd rather not hardcode a specific school in the general project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
