### PR TITLE
Rename VCHS schedule button to a year-agnostic label

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -46,7 +46,7 @@
 					})}
 					class="btn btn-secondary mt-3"
 				>
-					Valley Christian High School 2027 Schedule
+					Join this year's VCHS room
 				</a>
 			</div>
 			<a href={resolve('/credits')} class="link">Credits to our beta testers</a>


### PR DESCRIPTION
Follow-up to #84.

Renames the homepage shortcut button from **"Valley Christian High School 2027 Schedule"** to **"Join this year's VCHS room"**.

## Why
- Reads as a clearer call to action (*"Join …"*) rather than a static label.
- Drops the hardcoded year, so the copy doesn't go stale each school year.

The room link (`/room/9a7e704d-7772-435e-8af4-a258b1c68ebd`) is unchanged — this is a copy-only change to a single line in `src/routes/+page.svelte`, and `prettier` is happy with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)